### PR TITLE
Fix missing / in link.

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,7 +206,7 @@ dynamically combining many types of spatial data on demand for web users.
 Implementations vary widely,
 but some of the underlying techniques, software, semantics and formats have become
 accepted patterns
-(for example, <a href="https:/wiki.openstreetmap.org/wiki/Slippy_map_tilenames">the tile naming systems</a>),
+(for example, <a href="https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames">the tile naming systems</a>),
 or formal standards
 (for example, the <a href="https://www.opengeospatial.org/standards">standards published by the Open Geospatial Consortium</a>,
 some of which are also ISO standards).


### PR DESCRIPTION
The "tile naming systems" link was missing a / so it went to a 404 on GitHub rather than the intended page on the OSM wiki.