### PR TITLE
Add all draft use cases in client APIs section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3017,36 +3017,39 @@ A built-in web map solution would need to expose similar DOM APIs to JavaScript 
 <section id="use-case-create-initialise-display-map" data-ucr-role="use-case">
 <h4>Create, initialise, and display a map</h4>
 <p>
-An embedded map cannot usually be enhanced beyond the options available via URL configuration,
-and it may not be possible to extract additional information from the map or to subscribe to map events.
-For all use cases requiring the use of a client API, the first thing the web developer needs to do
-is to initialise and display a map.
+An embedded map cannot usually be enhanced beyond the
+options available via URL configuration, and it may not be
+possible to extract additional information from the map or
+to subscribe to map events.
+For all use cases requiring the use of a client API, the
+first thing the web developer needs to do is to initialise
+and display a map.
 </p>
 <p>
-See <a href="examples/client-apis/use-case-create-initialise-display-map.html" target="examples">
-examples of creating, initialising, and displaying a map
-</a>
+See <a href="examples/client-apis/use-case-create-initialise-display-map.html" target="examples">examples of creating, initialising, and displaying a map</a>
 as implemented by the reference JavaScript tools.
 </p>
 <p class="issue discussion" data-number="77">Discuss this section on GitHub.</p>
 <h5>Required capabilities</h5>
 <ul data-ucr-role="required-capabilities">
-<li><a href="#capability-create-initialise-and-display-map">Create, initialise, and display a map</a></li>
+<li><a href="#capability-create-initialise-and-display-a-map">Create, initialise, and display a map</a></li>
 </ul>
 </section>
 <section id="use-case-display-multiple-point-locations-single-map" data-ucr-role="use-case">
 <h4>Display multiple point locations on a single map</h4>
 <p>
-A web developer needs the ability to display a map with markers or other affordances denoting multiple specified locations.
+A web developer needs the ability to display a map with
+markers or other affordances denoting multiple specified
+locations.
 </p>
 <p>
-Example uses of such a map include search results (e.g. restaurants), traffic information (e.g. locations of roadworks),
-or the locations where photographs in a gallery were taken.
+Example uses of such a map include search results (e.g.
+restaurants), traffic information (e.g.
+locations of roadworks), or the locations where photographs
+in a gallery were taken.
 </p>
 <p>
-See <a href="examples/client-apis/use-case-display-multiple-point-locations-single-map.html" target="examples">
-examples of displaying multiple point locations on a single map
-</a>
+See <a href="examples/client-apis/use-case-display-multiple-point-locations-single-map.html" target="examples">examples of displaying multiple point locations on a single map</a>
 as implemented by the reference JavaScript tools.
 </p>
 <p class="issue discussion" data-number="78">Discuss this section on GitHub.</p>
@@ -3059,10 +3062,10 @@ as implemented by the reference JavaScript tools.
 <h4>Add a custom control to a map</h4>
 <p>
 A control is a user interface component that is integrated
-with a map. It may provide user feedback about the current
-state of the map, provide one or more affordances for
-manipulating the state of the map, or some combination of
-the two.
+with a map.
+It may provide user feedback about the current state of the
+map, provide one or more affordances for manipulating the
+state of the map, or some combination of the two.
 Typically, controls are integrated into the map display in
 such a way that no other map content can overlie or obscure
 them.
@@ -3104,7 +3107,7 @@ as implemented by the reference JavaScript tools.
 <p class="issue discussion" data-number="79">Discuss this section on GitHub.</p>
 <h5>Required capabilities</h5>
 <ul data-ucr-role="required-capabilities">
-<li><a href="#capability-implement-custom-control">Implement a custom control</a></li>
+<li><a href="#capability-implement-a-custom-control">Implement a custom control</a></li>
 <li><a href="#capability-add-control-map">Add a control to a map</a></li>
 <li><a href="#capability-remove-control-map">Remove a control from a map</a></li>
 </ul>
@@ -3133,9 +3136,7 @@ selecting a marker could highlight the corresponding list
 item.
 </p>
 <p>
-See <a href="examples/client-apis/use-case-provide-feedback-user-they-manipulate-map.html" target="examples">
-examples of providing feedback to a user as they manipulate the map
-</a>
+See <a href="examples/client-apis/use-case-provide-feedback-user-they-manipulate-map.html" target="examples">examples of providing feedback to a user as they manipulate the map</a>
 as implemented by the reference JavaScript tools.
 </p>
 <p class="issue discussion" data-number="80">Discuss this section on GitHub.</p>
@@ -3153,9 +3154,7 @@ as implemented by the reference JavaScript tools.
 Description to follow.
 </p>
 <p>
-See <a href="examples/client-apis/use-case-allow-user-select-different-style-map.html" target="examples">
-examples of allowing the user to select a different style for a map
-</a>
+See <a href="examples/client-apis/use-case-allow-user-select-different-style-map.html" target="examples">examples of allowing the user to select a different style for a map</a>
 as implemented by the reference JavaScript tools.
 </p>
 <p class="issue discussion" data-number="81">Discuss this section on GitHub.</p>
@@ -3171,10 +3170,7 @@ as implemented by the reference JavaScript tools.
 Example to be expanded later: NLS old Ordnance Survey maps.
 </p>
 <p>
-See
-<a href="examples/client-apis/use-case-allow-user-control-layer-displayed-map.html" target="examples">
-examples of allowing the user to control the layer displayed by a map
-</a>
+See <a href="examples/client-apis/use-case-allow-user-control-layer-displayed-map.html" target="examples">examples of allowing the user to control the layer displayed by a map</a>
 as implemented by the reference JavaScript tools.
 </p>
 <p class="issue discussion" data-number="82">Discuss this section on GitHub.</p>
@@ -3192,10 +3188,7 @@ as implemented by the reference JavaScript tools.
 Description to follow.
 </p>
 <p>
-See
-<a href="examples/client-apis/use-case-allow-user-reset-map-their-starting-point.html" target="examples">
-examples of allowing a user to reset the map to their starting point
-</a>
+See <a href="examples/client-apis/use-case-allow-user-reset-map-their-starting-point.html" target="examples">examples of allowing a user to reset the map to their starting point</a>
 as implemented by the reference JavaScript tools.
 </p>
 <p class="issue discussion" data-number="83">Discuss this section on GitHub.</p>
@@ -3208,18 +3201,20 @@ as implemented by the reference JavaScript tools.
 <section id="use-case-change-bearing-map" data-ucr-role="use-case">
 <h4>Change the bearing of a map</h4>
 <p>
-A developer may want the capability of changing the bearing of a map - that is,
-displaying the map with a direction other than North at the "top".
+A developer may want the capability of changing the bearing
+of a map - that is,
+displaying the map with a direction other than North at the
+"top".
 </p>
 <p>
-Examples include responding to the orientation of a device, traversing a route,
-and allowing the user to orient themselves with respect to the map by
+Examples include responding to the orientation of a device,
+traversing a route,
+and allowing the user to orient themselves with respect to
+the map by
 manipulating it with respect to local landmarks.
 </p>
 <p>
-See
-<a href="examples/client-apis/use-case-change-bearing-map.html" target="examples">
-examples of changing the bearing of a map</a>
+See <a href="examples/client-apis/use-case-change-bearing-map.html" target="examples">examples of changing the bearing of a map</a>
 as implemented by the reference JavaScript tools.
 </p>
 <p class="issue discussion" data-number="84">Discuss this section on GitHub.</p>
@@ -3229,7 +3224,7 @@ as implemented by the reference JavaScript tools.
 <li><a href="#capability-reset-bearing-map">Reset the bearing of a map</a></li>
 </ul>
 </section>
-<section id="use-case-specify-data-source-map-tile-layer" data-ucr-role="use-case">
+<section id="use-case-specify-a-data-source-for-a-map-tile-layer" data-ucr-role="use-case">
 <h4>Specify a data source for a map tile layer</h4>
 <p>
 For a web developer, the API capability of specifying the
@@ -3250,16 +3245,110 @@ The user interface for such a capability might be external
 to the map, or embedded within the map as a control.
 </p>
 <p>
-See <a href="examples/client-apis/use-case-specify-data-source-map-tile-layer.html" target="examples">examples of specifying a data source for a map tile layer</a>
+See <a href="examples/client-apis/use-case-specify-a-data-source-for-a-map-tile-layer.html" target="examples">examples of specifying a data source for a map tile layer</a>
 as implemented by the reference JavaScript tools.
 </p>
 <p class="issue discussion" data-number="85">Discuss this section on GitHub.</p>
 <h5>Required capabilities</h5>
 <ul data-ucr-role="required-capabilities">
+<li><a href="#capability-add-layer-map">Add a layer to a map</a></li>
+<li><a href="#capability-display-layer-map">Display a layer on a map</a></li>
+<li><a href="#capability-hide-layer-map">Hide a layer on a map</a></li>
 <li><a href="#capability-define-data-source-tile-layer">Define a data source for a tile layer</a></li>
 </ul>
 </section>
-
+<section id="use-case-show-a-vector-data-overlay-on-a-map" data-ucr-role="use-case">
+<h4>Show a vector data overlay on a map</h4>
+<p>
+Many forms of geographical data are available in vector
+formats, such as shapefiles describing the boundaries of
+administrative areas and poly lines representing a route.
+A web developer wishing to display such external data
+requires an API allowing it to be added as an overlay to the
+map view.
+</p>
+<p>
+See <a href="examples/client-apis/use-case-show-a-vector-data-overlay-on-a-map.html" target="examples">examples of showing a vector data overlay</a>
+as implemented by the reference JavaScript tools.
+</p>
+<p class="issue discussion" data-number="None">Discuss this section on GitHub.</p>
+<h5>Required capabilities</h5>
+<ul data-ucr-role="required-capabilities">
+<li><a href="#capability-add-layer-map">Add a layer to a map</a></li>
+<li><a href="#capability-create-an-overlay-defined-by-vector-data">Create an overlay defined by vector data</a></li>
+</ul>
+</section>
+<section id="use-case-show-a-heatmap-overlay-on-a-map" data-ucr-role="use-case">
+<h4>Show a heatmap overlay on a map</h4>
+<p>
+Heatmaps are a common way of showing the variation of some
+variable across a geographical area.
+A web developer wishing to display such data requires an API
+allowing such data to be added to a map as an overlay.
+</p>
+<p>
+See <a href="examples/client-apis/use-case-show-a-heatmap-overlay-on-a-map.html" target="examples">examples of showing a heatmap overlaid</a>
+as implemented by the reference JavaScript tools.
+</p>
+<p class="issue discussion" data-number="None">Discuss this section on GitHub.</p>
+<h5>Required capabilities</h5>
+<ul data-ucr-role="required-capabilities">
+<li><a href="#capability-display-layer-map">Display a layer on a map</a></li>
+<li><a href="#capability-create-an-overlay-defined-by-heatmap-data">Create an overlay defined by heatmap data</a></li>
+</ul>
+</section>
+<section id="use-case-move-a-map-to-a-new-position-andor-zoom-level" data-ucr-role="use-case">
+<h4>Move a map to a new position and/or zoom level</h4>
+<p>
+A web developer wishing to allow a user to select at will
+among a number of items will require the ability to move a
+map to a new position and/or zoom level.
+</p>
+<p>
+For example, the user may be choosing from a list of
+locations of interest, and expect the map to adjust to show
+the current point of interest at the centre.
+If the items among which the user is choosing are not points
+but areas, such as administrative regions, then the map may
+need not only to move but also to adjust its zoom level to
+one which best fits the area.
+</p>
+<p>
+See <a href="examples/client-apis/use-case-move-a-map-to-a-new-position-andor-zoom-level.html" target="examples">examples of moving a map to a new position and zoom level</a>
+as implemented by the reference JavaScript tools.
+</p>
+<p class="issue discussion" data-number="None">Discuss this section on GitHub.</p>
+<h5>Required capabilities</h5>
+<ul data-ucr-role="required-capabilities">
+<li><a href="#capability-zoom-map-or-out">Zoom a map in or out</a></li>
+<li><a href="#capability-move-the-map-to-display-a-given-location">Move the map to display a given location</a></li>
+<li><a href="#capability-pan-and-zoom-a-map-so-as-to-completely-show-the-area-covered-by-a-given-bounding-box">Pan and zoom a map so as to completely show the area covered by a given bounding box</a></li>
+</ul>
+</section>
+<section id="use-case-animate-a-map-through-a-sequence-of-points" data-ucr-role="use-case">
+<h4>Animate a map through a sequence of points</h4>
+<p>
+A web developer implementing the display of a number of
+locations arranged sequentially may require the ability to
+cause the map to animate through the locations by panning
+and zooming.
+</p>
+<p>
+Examples include traversing through the points that make up
+a set of directions, or through a set of locations that form
+part of a temporal sequence.
+</p>
+<p>
+See <a href="examples/client-apis/use-case-animate-a-map-through-a-sequence-of-points.html" target="examples">examples of animating a map through a sequence of points</a>
+as implemented by the reference JavaScript tools.
+</p>
+<p class="issue discussion" data-number="None">Discuss this section on GitHub.</p>
+<h5>Required capabilities</h5>
+<ul data-ucr-role="required-capabilities">
+<li><a href="#capability-animate-the-zooming-of-the-map">Animate the zooming of the map</a></li>
+<li><a href="#capability-animate-the-re-centering-of-the-map">Animate the re-centering of the map</a></li>
+</ul>
+</section>
 <section id="use-case-***" data-ucr-role="use-case">
 <h4><!-- Goal that user/author is trying to achieve --></h4>
 <p>


### PR DESCRIPTION
Once the use cases have been moved to a unified section, I can adjust the capabilities and examples to match (IDs in internal links and so forth) on the basis of the new stuff.