### PR TITLE
Add a few missing GH issue numbers and change "lazyload" to "lazy-load"

### DIFF
--- a/index.html
+++ b/index.html
@@ -1439,7 +1439,7 @@ as implemented by the reference JavaScript tools.
 <h5>Required capabilities</h5>
 <ul data-ucr-role="required-capabilities">
 <li><a href="#capability-single-custom-image"></a> or <a href="#capability-custom-map-tiles"></a></li>
-<li>For more complex maps, <a href="#capability-lazyload"></a> and <a href="#capability-zoom-swap"></a></li>
+<li>For more complex maps, <a href="#capability-lazy-load"></a> and <a href="#capability-zoom-swap"></a></li>
 <li>For adding custom maps from script, <a href="#capability-define-data-source-tile-layer">Define a data source for a tile layer</a></li>
 </ul>
 </section>
@@ -1586,7 +1586,7 @@ aligned screen dimensions (top-bottom and left-right).
 Test out map rotation on the <a href="examples/single-location.html" target="examples">basic single-location map views</a>
 for the reference JavaScript tools.
 </p>
-<p class="issue discussion" data-number="(GH issue number for discussion)">Discuss this section on GitHub.</p>
+<p class="issue discussion" data-number="114">Discuss this section on GitHub.</p>
 
 <h5>Required capabilities</h5>
 <ul data-ucr-role="required-capabilities">
@@ -1866,7 +1866,7 @@ as implemented by the reference JavaScript tools.
 
 <section id="use-case-set-layer-visibility" data-ucr-role="use-case">
 <h4>Control which layers are currently visible & which can be hidden by the user</h4>
-  
+
 <p>
 See <a href="examples/set-layer-visibility.html" target="examples">examples of allowing the user to control the layer displayed by a map</a>
 as implemented by the reference JavaScript tools.
@@ -1926,7 +1926,7 @@ without needing to pre-process it into a <a>raster layer</a>.
 See <a href="examples/heatmap.html" target="examples">examples of data heatmaps</a>
 as implemented by the reference JavaScript tools.
 </p>
-<p class="issue discussion" data-number="None">Discuss this section on GitHub.</p>
+<p class="issue discussion" data-number="119">Discuss this section on GitHub.</p>
 <h5>Required capabilities</h5>
 <ul data-ucr-role="required-capabilities">
 <li><a href="#capability-display-layer-map">Display a layer on a map</a></li>
@@ -2470,7 +2470,7 @@ But ideally, a basic map with text annotations and links should still work witho
 <p>
 A natively-supported, declarative web map viewer would by definition have this capability.
 </p>
-<p class="issue discussion" data-number="(GH issue number for discussion)">Discuss this section on GitHub.</p>
+<p class="issue discussion" data-number="32">Discuss this section on GitHub.</p>
 
 <h5>Existing implementations</h5>
 <p>
@@ -3314,7 +3314,7 @@ Thought is needed on how to make panning accessible to all users.
 </ul>
 </section>
 
-<section id="capability-lazyload" data-ucr-role="capability">
+<section id="capability-lazy-load" data-ucr-role="capability">
 <h4>Load additional map tiles when they pan into view</h4>
 <p>
 For web maps using a tileset,


### PR DESCRIPTION
Added GH issue numbers for:
[#use-case-rotate-map](https://maps4html.github.io/HTML-Map-Element-UseCases-Requirements/#use-case-rotate-map)
[#use-case-heatmap](https://maps4html.github.io/HTML-Map-Element-UseCases-Requirements/#use-case-heatmap)
[#capability-no-js](https://maps4html.github.io/HTML-Map-Element-UseCases-Requirements/#capability-no-js)

Also renamed "lazyload" to "lazy-load" per standardization effort mentioned in https://github.com/GoogleChrome/web.dev/pull/1016#discussion_r305585291.