### PR TITLE
upgrade insecure requests?

### DIFF
--- a/examples/add-custom-control.html
+++ b/examples/add-custom-control.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Add Custom Control — Maps for HTML reference examples</title>
   <link rel="stylesheet" href="examples.css" />

--- a/examples/alternative-layers.html
+++ b/examples/alternative-layers.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>Selectable alternative layers — Maps for HTML reference examples</title>
     <link rel="stylesheet" href="examples.css" />

--- a/examples/animate-view-change.html
+++ b/examples/animate-view-change.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>***Description*** — Maps for HTML reference examples</title>
   <link rel="stylesheet" href="examples.css" />

--- a/examples/change-bearing-map.html
+++ b/examples/change-bearing-map.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>***Description*** — Maps for HTML reference examples</title>
   <link rel="stylesheet" href="examples.css" />

--- a/examples/create-map.html
+++ b/examples/create-map.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Display an interactive map</title>
   <link rel="stylesheet" href="./examples.css"/>

--- a/examples/create-plugin-integrates-api.html
+++ b/examples/create-plugin-integrates-api.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>***Description*** — Maps for HTML reference examples</title>
   <link rel="stylesheet" href="examples.css" />

--- a/examples/custom-map.html
+++ b/examples/custom-map.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>Specify a data source for a map — Maps for HTML reference examples</title>
     <link rel="stylesheet" href="examples.css" />

--- a/examples/example-template.html
+++ b/examples/example-template.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>***Description*** — Maps for HTML reference examples</title>
   <link rel="stylesheet" href="examples.css" />

--- a/examples/generate-vector-features.html
+++ b/examples/generate-vector-features.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>***Description*** — Maps for HTML reference examples</title>
   <link rel="stylesheet" href="examples.css" />

--- a/examples/heatmap.html
+++ b/examples/heatmap.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>***Description*** — Maps for HTML reference examples</title>
   <link rel="stylesheet" href="examples.css" />

--- a/examples/html-annotations.html
+++ b/examples/html-annotations.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Display custom HTML annotations — Maps for HTML reference examples</title>
   <link rel="stylesheet" href="examples.css" />

--- a/examples/layers.html
+++ b/examples/layers.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Multi-layered maps — Maps for HTML reference examples</title>
   <link rel="stylesheet" href="examples.css" />

--- a/examples/multiple-location-markers.html
+++ b/examples/multiple-location-markers.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>Display multiple point locations as map markers — Maps for HTML reference examples</title>
     <link rel="stylesheet" href="examples.css" />

--- a/examples/poly-features.html
+++ b/examples/poly-features.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Display routes/paths or regions — Maps for HTML reference examples</title>
   <link rel="stylesheet" href="examples.css" />

--- a/examples/reset-map-view.html
+++ b/examples/reset-map-view.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>***Description*** — Maps for HTML reference examples</title>
   <link rel="stylesheet" href="examples.css" />

--- a/examples/set-layer-visibility.html
+++ b/examples/set-layer-visibility.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>***Description*** — Maps for HTML reference examples</title>
   <link rel="stylesheet" href="examples.css" />

--- a/examples/set-view-zoom.html
+++ b/examples/set-view-zoom.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>***Description*** — Maps for HTML reference examples</title>
   <link rel="stylesheet" href="examples.css" />

--- a/examples/single-location.html
+++ b/examples/single-location.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Single Location Map Views — Maps for HTML reference examples</title>
   <link rel="stylesheet" href="examples.css" />

--- a/examples/specify-data-source-map.html
+++ b/examples/specify-data-source-map.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>***Description*** — Maps for HTML reference examples</title>
   <link rel="stylesheet" href="examples.css" />

--- a/examples/static-map.html
+++ b/examples/static-map.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Static map display — Maps for HTML reference examples</title>
   <link rel="stylesheet" href="examples.css" />

--- a/examples/technical-drawings.html
+++ b/examples/technical-drawings.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Non-geographic content in map viewers — Maps for HTML reference examples</title>
   <link rel="stylesheet" href="examples.css" />

--- a/examples/view-change-events.html
+++ b/examples/view-change-events.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>***Description*** — Maps for HTML reference examples</title>
   <link rel="stylesheet" href="examples.css" />

--- a/index.html
+++ b/index.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<title>Use Cases and Requirements for Standardizing Web Maps</title>
 <meta charset='utf-8'>
+<meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
+<meta http-equiv="X-UA-Compatible" content="ie=edge">
+<title>Use Cases and Requirements for Standardizing Web Maps</title>
 <style>
 h5:not(.specificity-hack) {
   margin-top: 2rem;


### PR DESCRIPTION
<!--Adding [`upgrade-insecure-requests`](https://w3c.github.io/webappsec-upgrade-insecure-requests/) using CSP's [`<meta>` element delivery method](https://w3c.github.io/webappsec-csp/#meta-element) (to prevent [mixed content](https://w3c.github.io/webappsec-mixed-content/) blocking) to all examples, and to the spec 
-->
Future-proof potential issues with HTTP links by setting [`upgrade-insecure-requests`](https://w3c.github.io/webappsec-upgrade-insecure-requests/) through CSP's [`<meta>` element delivery method](https://w3c.github.io/webappsec-csp/#meta-element) as proposed in https://github.com/Maps4HTML/HTML-Map-Element-UseCases-Requirements/issues/126#issuecomment-524376011.

For **links to third-parties**; only "non-navigational upgrades" are applied (e.g. upgrade a script from http to https). But "navigational upgrades" aren't applied (meaning if we link to an external website using `<a href="http://...">` it wont be upgraded to https).

[non-navigational upgrades](https://w3c.github.io/webappsec-upgrade-insecure-requests/#example-nonnavigational):
> This automatically upgrades all insecure resource requests from their pages to secure variants, allowing a user agent to treat the following HTML code:
> 
> ```HTML
> <img src="http://example.com/image.png">
> <img src="http://not-example.com/image.png">
> ```
> as though it had been delivered as:
> 
> ```HTML
> <img src="https://example.com/image.png">
> <img src="https://not-example.com/image.png">
> ```
[navigational upgrades](https://w3c.github.io/webappsec-upgrade-insecure-requests/#example-navigation):
> This allows user agents to treat the following HTML code:
> ```HTML
> <a href="http://example.com/">Home</a>
> ```
> as though it had been delivered as:
> 
> ```HTML
> <a href="https://example.com/">Home</a>
> ```
> Links to third-party sites will not be upgraded. That is, the following HTML code:
> ```HTML
> `<a href="http://not-example.com/">Home</a>
> ```
> won’t be upgraded.