### PR TITLE
Cross-reference use cases from capabilities

### DIFF
--- a/index.html
+++ b/index.html
@@ -5456,7 +5456,6 @@ function processCapability(node) {
     const supportedUseCaseLinks = [...document.querySelectorAll(`[data-ucr-role='required-capabilities'] [href='#${id}']`)];
     supportedUseCaseLinks.forEach((link) => {
       const useCase = link.closest("[data-ucr-role='use-case']");
-      const useCaseTitle = findSectionTitle(useCase);
       const a = document.createElement('a');
       a.appendChild(document.createTextNode(useCaseTitle));
       a.href = `#${useCase.id}`;

--- a/index.html
+++ b/index.html
@@ -5450,7 +5450,21 @@ function processCapability(node) {
     : "undecided";
   if (conclusionNode) processTag(conclusionNode, conclusionDict);
 
-  // TODO: extract the “supported use cases” & generate cross references
+  // extract the “supported use cases” & generate cross references
+  const capabilityUseCasesList = node.querySelector("ul[data-ucr-role='capability-uses']");
+  if (capabilityUseCasesList) {
+    const supportedUseCaseLinks = [...document.querySelectorAll(`[data-ucr-role='use-case'] [href='#${id}']`)];
+    supportedUseCaseLinks.forEach((link) => {
+      const useCase = link.closest("[data-ucr-role='use-case']");
+      const useCaseTitle = findSectionTitle(useCase);
+      const a = document.createElement('a');
+      a.appendChild(document.createTextNode(useCaseTitle));
+      a.href = `#${useCase.id}`;
+      const li = document.createElement('li');
+      li.appendChild(a);
+      capabilityUseCasesList.appendChild(li);
+    });
+  }
 
   return { node, name, id, conclusion,
            tags: [], implementations: {} };

--- a/index.html
+++ b/index.html
@@ -5433,7 +5433,7 @@ let conclusionDict = dictFromArray(conclusionDfns);
 function findSectionTitle(node) {
   let heading = node.querySelector("h2,h3,h4,h5,h6")
         || node.firstElementChild || node;
-  return node.textContent.trim();
+  return heading.textContent.trim();
 }
 function processUseCase(node) {
   let name = findSectionTitle(node);

--- a/index.html
+++ b/index.html
@@ -5457,7 +5457,6 @@ function processCapability(node) {
     supportedUseCaseLinks.forEach((link) => {
       const useCase = link.closest("[data-ucr-role='use-case']");
       const a = document.createElement('a');
-      a.appendChild(document.createTextNode(useCaseTitle));
       a.href = `#${useCase.id}`;
       const li = document.createElement('li');
       li.appendChild(a);

--- a/index.html
+++ b/index.html
@@ -5453,7 +5453,7 @@ function processCapability(node) {
   // extract the “supported use cases” & generate cross references
   const capabilityUseCasesList = node.querySelector("ul[data-ucr-role='capability-uses']");
   if (capabilityUseCasesList) {
-    const supportedUseCaseLinks = [...document.querySelectorAll(`[data-ucr-role='use-case'] [href='#${id}']`)];
+    const supportedUseCaseLinks = [...document.querySelectorAll(`[data-ucr-role='required-capabilities'] [href='#${id}']`)];
     supportedUseCaseLinks.forEach((link) => {
       const useCase = link.closest("[data-ucr-role='use-case']");
       const useCaseTitle = findSectionTitle(useCase);


### PR DESCRIPTION
I've implemented this TODO from the preprocessing script separately from other changes as it isn't related to anything else (and I'm finding it useful to have the links in the page while I work).

Not all capabilities currently have a "Supported use cases" section so this implementation only looks for referencing use cases for those that do. If those capabilities are supposed to have such a section, this could be simplified slightly once they're added, but it's probably safest with that check in.