### PR TITLE
Lazy-loading does not have to rely on JavaScript

### DIFF
--- a/index.html
+++ b/index.html
@@ -3389,7 +3389,7 @@ Thought is needed on how to make panning accessible to all users.
 <p>
 For web maps using a tileset,
 an initial series of tiles is loaded based on the current position of the map.
-Additional tiles are then loaded using JavaScript when they are panned into view.
+Tiles are <a href="https://web.dev/native-lazy-loading">lazily loaded</a>, and as such additional ones are loaded when they are panned into view.
 This allows for a smaller initial payload and improved performance.
 </p>
 <p>

--- a/index.html
+++ b/index.html
@@ -3389,7 +3389,7 @@ Thought is needed on how to make panning accessible to all users.
 <p>
 For web maps using a tileset,
 an initial series of tiles is loaded based on the current position of the map.
-Tiles are <a href="https://web.dev/native-lazy-loading">lazily loaded</a>,
+Tiles are lazily loaded,
 and as such additional ones are loaded when they are panned into view.
 This allows for a smaller initial payload and improved performance.
 </p>

--- a/index.html
+++ b/index.html
@@ -3389,7 +3389,8 @@ Thought is needed on how to make panning accessible to all users.
 <p>
 For web maps using a tileset,
 an initial series of tiles is loaded based on the current position of the map.
-Tiles are <a href="https://web.dev/native-lazy-loading">lazily loaded</a>, and as such additional ones are loaded when they are panned into view.
+Tiles are <a href="https://web.dev/native-lazy-loading">lazily loaded</a>,
+and as such additional ones are loaded when they are panned into view.
 This allows for a smaller initial payload and improved performance.
 </p>
 <p>


### PR DESCRIPTION
Rewording the sentence on lazily loading tiles, as it explicitly calls out a need for JS which isn't quite true as browsers are starting to implement native lazy-loading.

I included a link to https://web.dev/native-lazy-loading, as it is the best up-to-date resource on lazy-loading in my opinion.