### PR TITLE
Correct invalid CSS value

### DIFF
--- a/examples/examples.css
+++ b/examples/examples.css
@@ -211,7 +211,7 @@ a[data-type='point']::before {
     flex-basis: 1;
     font-weight: bold;
     font-size: 1.2rem;
-    margin-bottom: 5.rem;
+    margin-bottom: .5rem;
     min-height: 2rem;
 }
 


### PR DESCRIPTION
Change invalid `margin-bottom` value from `5.rem` to `.5rem` (this is for the `.go` button(s) in https://maps4html.github.io/HTML-Map-Element-UseCases-Requirements/examples/animate-view-change.html)