### PR TITLE
Example pages - same size iframes

### DIFF
--- a/examples/alternative-layers.html
+++ b/examples/alternative-layers.html
@@ -52,7 +52,9 @@ but may or may not provide a standard control enabling users to choose among the
 <section id="google-maps-embed">
   <h2>Google Maps embed</h2>
   <p>Embedded Google Maps include the satellite/street map layer selection control by default.</p>
-  <iframe src="https://www.google.com/maps/embed" width="600" height="450" frameborder="0" style="border:0" allowfullscreen></iframe>
+  <iframe width="600" height="450" allowfullscreen allow="fullscreen"
+    src="https://www.google.com/maps/embed">
+  </iframe>
 </section>
 
 <section id="openstreetmap">

--- a/examples/change-bearing-map.html
+++ b/examples/change-bearing-map.html
@@ -66,8 +66,8 @@ to demonstrate that the map view can be dynamically updated in this respect.
 <section id="mapbox-embed">
   <h2>MapBox Studio embed</h2>
   <div>
-    <iframe width="500" height="400" frameborder="0"
-            src="https://api.mapbox.com/styles/v1/nchan0154/cjx9sxbqt08611cp94xvmkwu1.html?fresh=true&amp;access_token=pk.eyJ1IjoibmNoYW4wMTU0IiwiYSI6ImNqeDlzd3BrNjAxcjAzeXFuMjdodGowbnMifQ.wmDpzNGfADuQOSn1dABh7A#2/0/0/45">
+    <iframe width="600" height="450"
+      src="https://api.mapbox.com/styles/v1/nchan0154/cjx9sxbqt08611cp94xvmkwu1.html?fresh=true&amp;access_token=pk.eyJ1IjoibmNoYW4wMTU0IiwiYSI6ImNqeDlzd3BrNjAxcjAzeXFuMjdodGowbnMifQ.wmDpzNGfADuQOSn1dABh7A#2/0/0/45">
     </iframe>
   </div>
 </section>

--- a/examples/create-map.html
+++ b/examples/create-map.html
@@ -53,22 +53,34 @@ the examples in those cases use OpenStreetMap tiles.
 
 <section id="google-maps-embed">
   <h2>Google Maps</h2>
-  <iframe src="https://www.google.com/maps/embed" width="600" height="450" frameborder="0" style="border:0" allowfullscreen></iframe>
+  <iframe width="600" height="450" allowfullscreen allow="fullscreen"
+    src="https://www.google.com/maps/embed">
+  </iframe>
 </section>
 
 <section id="openstreetmap">
   <h2>OpenStreetMap</h2>
-  <iframe width="425" height="350" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://www.openstreetmap.org/export/embed.html" style="border: 1px solid black"></iframe><br/><small><a href="https://www.openstreetmap.org/">View Larger Map</a></small>
+  <iframe width="600" height="450" scrolling="no"
+    src="https://www.openstreetmap.org/export/embed.html">
+  </iframe>
+  <div class="map-links">
+    <small>
+      <a href="https://www.openstreetmap.org/">View Larger Map</a>
+    </small>
+  </div>
 </section>
 
 <section id="bing-maps-embed">
   <h2>Bing Maps</h2>
   <div>
-      <iframe width="500" height="400" frameborder="0" src="https://www.bing.com/maps/embed?h=400&w=500&cp=27.683528083787735~5.306411922086829&lvl=1&typ=d&sty=r&src=SHELL&FORM=MBEDV8" scrolling="no">
+      <iframe width="600" height="450" scrolling="no"
+        src="https://www.bing.com/maps/embed?w=600&h=450&cp=27.683528083787735~5.306411922086829&lvl=1&typ=d&sty=r&src=SHELL&FORM=MBEDV8">
       </iframe>
-      <div class="bing-maps-links">
-         <a id="largeMapLink" target="_blank" href="https://www.bing.com/maps?cp=27.683528083787735~5.306411922086829&amp;sty=r&amp;lvl=1&amp;FORM=MBEDLD">View Larger Map</a> &nbsp; | &nbsp;
-         <a id="dirMapLink" target="_blank" href="https://www.bing.com/maps/directions?cp=27.683528083787735~5.306411922086829&amp;sty=r&amp;lvl=1&amp;rtp=~pos.27.683528083787735_5.306411922086829____&amp;FORM=MBEDLD">Get Directions</a>
+      <div class="map-links">
+        <small>
+          <a id="largeMapLink" target="_blank" href="https://www.bing.com/maps?cp=27.683528083787735~5.306411922086829&amp;sty=r&amp;lvl=1&amp;FORM=MBEDLD">View Larger Map</a> &nbsp; | &nbsp;
+          <a id="dirMapLink" target="_blank" href="https://www.bing.com/maps/directions?cp=27.683528083787735~5.306411922086829&amp;sty=r&amp;lvl=1&amp;rtp=~pos.27.683528083787735_5.306411922086829____&amp;FORM=MBEDLD">Get Directions</a>
+       </small>
      </div>
   </div>
 </section>
@@ -76,7 +88,7 @@ the examples in those cases use OpenStreetMap tiles.
 <section id="mapbox-embed">
   <h2>MapBox Studio embed</h2>
   <div>
-    <iframe width="500" height="400" frameborder="0"
+    <iframe width="600" height="450"
       src="https://api.mapbox.com/styles/v1/nchan0154/cjx9sxbqt08611cp94xvmkwu1.html?fresh=true&amp;access_token=pk.eyJ1IjoibmNoYW4wMTU0IiwiYSI6ImNqeDlzd3BrNjAxcjAzeXFuMjdodGowbnMifQ.wmDpzNGfADuQOSn1dABh7A#0/0/0">
     </iframe>
   </div>

--- a/examples/custom-map.html
+++ b/examples/custom-map.html
@@ -26,21 +26,21 @@ The TileJSON representation of the map, as a JavaScript object, is:
 
 <div class="script-example">
   <script>
-  m4h.fiskMapJSON = {
-    "tilejson": "2.2.0",
-    "name": "Mississippi Stream Courses sheet 4 - Harold Fisk, US Army Corps of Engineers",
-    "attribution": "Presidential Mississippi River Commission, 1944. Public Domain.",
-    "scheme": "tms",
-    "tiles": [
-      "https://maps4html.github.io/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{-y}.png"
-    ],
-    "bounds": [-92.60431421311640, 28.79036396296392, -88.72531489137181, 31.04551669046586],
-    "minzoom": 6,
-    "maxzoom": 12
-  };
+    m4h.fiskMapJSON = {
+      "tilejson": "2.2.0",
+      "name": "Mississippi Stream Courses sheet 4 - Harold Fisk, US Army Corps of Engineers",
+      "attribution": "Presidential Mississippi River Commission, 1944. Public Domain.",
+      "scheme": "tms",
+      "tiles": [
+        "https://maps4html.github.io/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{-y}.png"
+      ],
+      "bounds": [-92.60431421311640, 28.79036396296392, -88.72531489137181, 31.04551669046586],
+      "minzoom": 6,
+      "maxzoom": 12
+    };
   </script>
 </div>
-  
+
 <details>
   <summary>Jump to section…</summary>
   <ul class="toc">

--- a/examples/examples.css
+++ b/examples/examples.css
@@ -43,7 +43,6 @@ h1 a:link, h1 a:visited {
   display: block;
   white-space: pre;
   font-family: monospace;
-  overflow: visible;
   position: relative;
   padding: 0 2rem 1rem 0;
   z-index: 2;
@@ -54,7 +53,6 @@ h1 a:link, h1 a:visited {
   border: 1px solid #ccc;
   border-radius: 2px;
   margin-top: 1rem;
-  overflow-x: visible;
 }
 
 .script-example::before {

--- a/examples/examples.css
+++ b/examples/examples.css
@@ -43,7 +43,6 @@ h1 a:link, h1 a:visited {
   display: block;
   white-space: pre;
   font-family: monospace;
-  position: relative;
   padding: 0 2rem 1rem 0;
   z-index: 2;
   overflow-x: auto;

--- a/examples/examples.css
+++ b/examples/examples.css
@@ -7,8 +7,12 @@
 html {
   background-color: #fefefe;
   color: #222;
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   overflow-x: hidden;
+}
+
+html,
+.script-example::before {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
 body {
@@ -34,15 +38,16 @@ h1 a:link, h1 a:visited {
   margin-bottom: 1rem;
 }
 
+.script-example code,
 .script-example script {
   display: block;
   white-space: pre;
   font-family: monospace;
   overflow: visible;
   position: relative;
-  padding: 0 2rem 2rem 0;
+  padding: 0 2rem 1rem 0;
   z-index: 2;
-  overflow-y: auto;
+  overflow-x: auto;
 }
 
 .script-example {
@@ -106,6 +111,13 @@ a[data-type='point']::before {
     content: 'Place: '
 }
 
+.map-links {
+  text-align: center;
+  width: 100%;
+  padding: 6px 0;
+  max-width: 600px;
+}
+
 .custom-control {
     border: 1px solid #000;
     background-color: #fefefe;
@@ -151,13 +163,6 @@ a[data-type='point']::before {
 
 .controls .primary {
     font-weight: bold;
-}
-
-.bing-maps-links {
-  text-align: center;
-  width: 500px;
-  padding: 6px 0;
-  max-width: 100%;
 }
 
 .bing.custom-control.lat-lng {
@@ -211,7 +216,7 @@ a[data-type='point']::before {
     flex-basis: 1;
     font-weight: bold;
     font-size: 1.2rem;
-    margin-bottom: 5.rem;
+    margin-bottom: .5rem;
     min-height: 2rem;
 }
 

--- a/examples/multiple-location-markers.html
+++ b/examples/multiple-location-markers.html
@@ -47,7 +47,9 @@ Default marker icons are used where available.
 
 <section id="google-maps-embed">
   <h2>Google Maps embed</h2>
-  <iframe src="https://www.google.com/maps/d/u/3/embed?mid=1-EYJtP47B73kl2ciW-B5Mqh11_JzuRHj" width="640" height="480"></iframe>
+  <iframe width="600" height="450"
+    src="https://www.google.com/maps/d/u/3/embed?mid=1-EYJtP47B73kl2ciW-B5Mqh11_JzuRHj">
+  </iframe>
 </section>
 
 <section id="openstreetmap">
@@ -68,8 +70,8 @@ Default marker icons are used where available.
 
 <section id="mapbox-embed">
   <h2>MapBox Studio embed</h2>
-  <iframe width="500" height="400" frameborder="0"
-      src="https://api.mapbox.com/styles/v1/nchan0154/cjzc7vixs0jzg1cpg1aih90ur.html?fresh=true&access_token=pk.eyJ1IjoibmNoYW4wMTU0IiwiYSI6ImNqeDlzd3BrNjAxcjAzeXFuMjdodGowbnMifQ.wmDpzNGfADuQOSn1dABh7A#12.9/46.231226/6.051737/0">
+  <iframe width="600" height="450"
+    src="https://api.mapbox.com/styles/v1/nchan0154/cjzc7vixs0jzg1cpg1aih90ur.html?fresh=true&access_token=pk.eyJ1IjoibmNoYW4wMTU0IiwiYSI6ImNqeDlzd3BrNjAxcjAzeXFuMjdodGowbnMifQ.wmDpzNGfADuQOSn1dABh7A#12.9/46.231226/6.051737/0">
   </iframe>
 </section>
 

--- a/examples/set-layer-visibility.html
+++ b/examples/set-layer-visibility.html
@@ -25,19 +25,20 @@ The maps used here are the four sheets of plate 15 of the report.
 An example of the TileJSON representation of the map is:
 
 </p>
-<pre class="example"><code>
-{
-    "tilejson": "2.2.0",
-    "name": "Mississippi Stream Courses sheet 4 - Harold Fisk, US Army Corps of Engineers",
-    "attribution": "Presidential Mississippi River Commission, 1944. Public Domain.",
-    "scheme": "tms",
-    "tiles": [
-      "https://maps4html.github.io/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{-y}.png"
-    ],
-    "bounds": [-92.60431421311640, 28.79036396296392, -88.72531489137181, 31.04551669046586],
-    "minzoom": 6,
-    "maxzoom": 12
-};
+<pre class="script-example">
+<code>
+    {
+      "tilejson": "2.2.0",
+      "name": "Mississippi Stream Courses sheet 4 - Harold Fisk, US Army Corps of Engineers",
+      "attribution": "Presidential Mississippi River Commission, 1944. Public Domain.",
+      "scheme": "tms",
+      "tiles": [
+        "https://maps4html.github.io/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{-y}.png"
+      ],
+      "bounds": [-92.60431421311640, 28.79036396296392, -88.72531489137181, 31.04551669046586],
+      "minzoom": 6,
+      "maxzoom": 12
+    };
 </code>
 </pre>
 

--- a/examples/single-location.html
+++ b/examples/single-location.html
@@ -66,21 +66,34 @@ for how to add point markers with the other services (where possible).
 
 <section id="google-maps-embed">
   <h2>Google Maps embed</h2>
-  <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d44156.06881542181!2d6.0130244457978295!3d46.23523057360836!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x478c62fcec737b11%3A0x81bef3ae7a885e31!2sCERN!5e0!3m2!1sen!2sca!4v1552858082440" width="600" height="450" frameborder="0" style="border:0" allowfullscreen></iframe>
+  <iframe width="600" height="450" allowfullscreen allow="fullscreen"
+    src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d44156.06881542181!2d6.0130244457978295!3d46.23523057360836!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x478c62fcec737b11%3A0x81bef3ae7a885e31!2sCERN!5e0!3m2!1sen!2sca!4v1552858082440">
+  </iframe>
 </section>
 
 <section id="openstreetmap">
   <h2>OpenStreetMap embed</h2>
-  <iframe width="425" height="350" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://www.openstreetmap.org/export/embed.html?bbox=6.052817702293396%2C46.23131259369175%2C6.056969761848451%2C46.235594723049495&amp;layer=mapnik&amp;marker=46.23345370013554%2C6.054893732070923" style="border: 1px solid black"></iframe><br/><small><a href="https://www.openstreetmap.org/?mlat=46.23345&amp;mlon=6.05489#map=18/46.23345/6.05489">View Larger Map</a></small>
+  <iframe width="600" height="450" scrolling="no"
+    src="https://www.openstreetmap.org/export/embed.html?bbox=6.052817702293396%2C46.23131259369175%2C6.056969761848451%2C46.235594723049495&amp;layer=mapnik&amp;marker=46.23345370013554%2C6.054893732070923">
+  </iframe>
+  <div class="map-links">
+    <small>
+      <a href="https://www.openstreetmap.org/?mlat=46.23345&amp;mlon=6.05489#map=18/46.23345/6.05489">View Larger Map</a>
+    </small>
+  </div>
 </section>
 
 <section id="bing-maps-embed">
 <h2>Bing Maps embed</h2>
   <div>
-    <iframe width="500" height="400" frameborder="0" src="https://www.bing.com/maps/embed?h=400&w=500&cp=46.23234202714631~6.070279394261964&lvl=14&typ=d&sty=r&src=SHELL&FORM=MBEDV8" scrolling="no"></iframe>
-    <div class="bing-maps-links">
-     <a id="largeMapLink" target="_blank" href="https://www.bing.com/maps?cp=46.23234202714631~6.070279394261964&amp;sty=r&amp;lvl=14&amp;FORM=MBEDLD">View Larger Map</a> &nbsp; | &nbsp;
-     <a id="dirMapLink" target="_blank" href="https://www.bing.com/maps/directions?cp=46.23234202714631~6.070279394261964&amp;sty=r&amp;lvl=14&amp;rtp=~pos.46.23234202714631_6.070279394261964____&amp;FORM=MBEDLD">Get Directions</a>
+    <iframe width="600" height="450" scrolling="no"
+      src="https://www.bing.com/maps/embed?w=600&h=450&cp=46.23234202714631~6.070279394261964&lvl=14&typ=d&sty=r&src=SHELL&FORM=MBEDV8">
+    </iframe>
+    <div class="map-links">
+      <small>
+        <a id="largeMapLink" target="_blank" href="https://www.bing.com/maps?cp=46.23234202714631~6.070279394261964&amp;sty=r&amp;lvl=14&amp;FORM=MBEDLD">View Larger Map</a> &nbsp; | &nbsp;
+        <a id="dirMapLink" target="_blank" href="https://www.bing.com/maps/directions?cp=46.23234202714631~6.070279394261964&amp;sty=r&amp;lvl=14&amp;rtp=~pos.46.23234202714631_6.070279394261964____&amp;FORM=MBEDLD">Get Directions</a>
+      </small>
    </div>
   </div>
 </section>
@@ -88,7 +101,7 @@ for how to add point markers with the other services (where possible).
 <section id="mapbox-embed">
   <h2>MapBox Studio embed</h2>
   <div>
-    <iframe width="500" height="400" frameborder="0"
+    <iframe width="500" height="400"
       src="https://api.mapbox.com/styles/v1/nchan0154/cjx9tt51t2d7d1dl7z92tnjks.html?fresh=true&access_token=pk.eyJ1IjoibmNoYW4wMTU0IiwiYSI6ImNqeDlzd3BrNjAxcjAzeXFuMjdodGowbnMifQ.wmDpzNGfADuQOSn1dABh7A#12.9/46.234099/6.055079/0">
     </iframe>
   </div>
@@ -311,7 +324,7 @@ for how to add point markers with the other services (where possible).
 
 <section id="d3-geo">
   <h2>D3 Geographies APIs</h2>
-  
+
   ***TODO<!--
   Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
   or <p>Not applicable</p>


### PR DESCRIPTION
Make all iframe embeds have the same dimensions as specified in the `width` and `height` attrs.

So instead of smaller iframes for some embeds (to the left in the image below), all the iframes will be the same size (same as the JS implementations as well):

![maps_same-size](https://user-images.githubusercontent.com/26493779/65510582-97576c00-ded5-11e9-8e04-5f4536960855.png)

<hr>

Also removed redundant attributes and inline styles in regards to borders such as `style="border: 0"` and `frameborder="0"` as that is handled in examples.css.

&plus; minor style clean-up.

Fix https://github.com/Maps4HTML/HTML-Map-Element-UseCases-Requirements/pull/175.