### PR TITLE
Clean up markup (example pages)

### DIFF
--- a/examples/add-custom-control.html
+++ b/examples/add-custom-control.html
@@ -144,7 +144,7 @@
 <section id="openlayers">
   <h2>OpenLayers with OpenStreetMap tiles</h2>
   <div id="openlayers-map" style="width: 600px; height: 450px;"></div>
-  <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css" type="text/css">
+  <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css">
   <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
   <div class="script-example">
     <script>
@@ -386,8 +386,8 @@
 <section id="mapbox-api">
   <h2>MapBox GL</h2>
   <div id="mapbox-api-map" style="width: 600px; height: 450px;"></div>
-  <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css' rel='stylesheet' />
-  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js'></script>
+  <link rel="stylesheet" href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css">
+  <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <div class="script-example">
     <script>
         { // block to restrict let and const scope to this example

--- a/examples/alternative-layers.html
+++ b/examples/alternative-layers.html
@@ -114,6 +114,7 @@ but may or may not provide a standard control enabling users to choose among the
 <section id="openlayers">
   <h2>OpenLayers with OpenStreetMap tiles</h2>
   <div id="openlayers-map" style="width: 600px; height: 450px;"></div>
+  <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css">
   <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
   <div class="script-example">
     <script>
@@ -244,8 +245,8 @@ but may or may not provide a standard control enabling users to choose among the
 <section id="mapbox-api">
   <h2>Mapbox GL JS API</h2>
   <div id="mapbox-api-map" style="width: 600px; height: 450px;"></div>
-  <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css' rel='stylesheet' />
-  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js'></script>
+  <link rel="stylesheet" href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css">
+  <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <div class="script-example">
     <script>
       {

--- a/examples/animate-view-change.html
+++ b/examples/animate-view-change.html
@@ -99,7 +99,7 @@ Other libraries require the developer to implement the sequencing of animations 
     <div class="map" id="openlayers-map">
     </div>
   </div>
-  <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css" type="text/css">
+  <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css">
   <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
   <div class="script-example">
     <script>

--- a/examples/change-bearing-map.html
+++ b/examples/change-bearing-map.html
@@ -80,6 +80,7 @@ to demonstrate that the map view can be dynamically updated in this respect.
 <section id="openlayers">
   <h2>OpenLayers with OpenStreetMap tiles</h2>
   <div id="ol-osm-use-case-change-bearing-map" style="width: 600px; height: 450px;"></div>
+  <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css">
   <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
   <div class="script-example">
     <script>
@@ -148,8 +149,8 @@ to demonstrate that the map view can be dynamically updated in this respect.
 <section id="mapbox-api">
   <h2>Mapbox GL JS API</h2>
   <div id="mapbox-api-map" style="width: 600px; height: 450px;"></div>
-  <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css' rel='stylesheet' />
-  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js'></script>
+  <link rel="stylesheet" href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css">
+  <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <div class="script-example">
     <script>
       {

--- a/examples/create-map.html
+++ b/examples/create-map.html
@@ -120,7 +120,7 @@ the examples in those cases use OpenStreetMap tiles.
 <section id="openlayers">
   <h2>OpenLayers (with OpenStreetMap tiles)</h2>
   <div id="openlayers-map" style="width: 600px; height: 450px;"></div>
-  <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css" type="text/css">
+  <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css">
   <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
   <div class="script-example">
     <script>
@@ -228,8 +228,8 @@ the examples in those cases use OpenStreetMap tiles.
 <section id="mapbox-api">
   <h2>MapBox GL</h2>
   <div id="mapbox-api-map" style="width: 600px; height: 450px;"></div>
-  <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css' rel='stylesheet' />
-  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js'></script>
+  <link rel="stylesheet" href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css">
+  <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <div class="script-example">
     <script>
       {
@@ -247,9 +247,9 @@ the examples in those cases use OpenStreetMap tiles.
 <section id="tomtom">
   <h2>TomTom Maps SDK for Web with vector maps</h2>
   <div id="tomtom-map" style="width: 600px; height: 450px;"></div>
-  <script src='https://api.tomtom.com/maps-sdk-js/4.47.6/examples/sdk/tomtom.min.js'></script>
-  <!--<link rel='stylesheet' href='https://api.tomtom.com/maps-sdk-js/4.47.6/examples/sdk/map.css'>-->
-  <link rel='stylesheet' href='https://api.tomtom.com/maps-sdk-js/4.47.6/examples/elements.css'>
+  <script src="https://api.tomtom.com/maps-sdk-js/4.47.6/examples/sdk/tomtom.min.js"></script>
+  <!--<link rel="stylesheet" href="https://api.tomtom.com/maps-sdk-js/4.47.6/examples/sdk/map.css">-->
+  <link rel="stylesheet" href="https://api.tomtom.com/maps-sdk-js/4.47.6/examples/elements.css">
   <div class="script-example">
     <script>
       {

--- a/examples/custom-map.html
+++ b/examples/custom-map.html
@@ -110,7 +110,7 @@ The TileJSON representation of the map, as a JavaScript object, is:
 <section id="openlayers">
   <h2>OpenLayers with OpenStreetMap tiles</h2>
   <div id="openlayers-map" style="width: 600px; height: 450px; background-color: #ccc;"></div>
-  <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css" type="text/css">
+  <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css">
   <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
   <div class="script-example">
     <script>
@@ -298,8 +298,8 @@ The TileJSON representation of the map, as a JavaScript object, is:
 <section id="mapbox-api">
   <h2>MapBox GL</h2>
   <div id="mapbox-api-map" style="width: 600px; height: 450px;"></div>
-  <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css' rel='stylesheet' />
-  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js'></script>
+  <link rel="stylesheet" href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css">
+  <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <div class="script-example">
     <script>
       {

--- a/examples/multiple-location-markers.html
+++ b/examples/multiple-location-markers.html
@@ -107,7 +107,7 @@ Default marker icons are used where available.
 <section id="openlayers">
     <h2>OpenLayers with OpenStreetMap tiles</h2>
     <div id="openlayers-map" style="width: 600px; height: 450px;"></div>
-    <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css">
     <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
     <div class="script-example">
       <script>
@@ -274,8 +274,8 @@ Default marker icons are used where available.
 <section id="mapbox-api">
   <h2>MapBox GL</h2>
   <div id="mapbox-api-map" style="width: 600px; height: 450px;"></div>
-  <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css' rel='stylesheet' />
-  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js'></script>
+  <link rel="stylesheet" href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css">
+  <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <div class="script-example">
     <script>
       {
@@ -302,9 +302,9 @@ Default marker icons are used where available.
 <section id="tomtom">
   <h2>TomTom Maps SDK for Web with vector maps</h2>
   <div id="tomtom-multiple-points" style="width: 600px; height: 450px;"></div>
-  <script src='https://api.tomtom.com/maps-sdk-js/4.47.6/examples/sdk/tomtom.min.js'></script>
-  <!-- <link rel='stylesheet' href='https://api.tomtom.com/maps-sdk-js/4.47.6/examples/sdk/map.css'> -->
-  <link rel='stylesheet' href='https://api.tomtom.com/maps-sdk-js/4.47.6/examples/elements.css'>
+  <script src="https://api.tomtom.com/maps-sdk-js/4.47.6/examples/sdk/tomtom.min.js"></script>
+  <!--<link rel="stylesheet" href="https://api.tomtom.com/maps-sdk-js/4.47.6/examples/sdk/map.css">-->
+  <link rel="stylesheet" href="https://api.tomtom.com/maps-sdk-js/4.47.6/examples/elements.css">
   <!-- Tomtom's CSS does some strange things to leaflet, so we have to pluck out the icon styles out of their CSS-->
   <style>
   .icon-marker-black {

--- a/examples/set-layer-visibility.html
+++ b/examples/set-layer-visibility.html
@@ -146,7 +146,7 @@ An example of the TileJSON representation of the map is:
 <section id="openlayers">
   <h2>OpenLayers with OpenStreetMap tiles</h2>
   <div id="ol-osm-alternative-layers" style="width: 600px; height: 450px;"></div>
-  <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css" type="text/css">
+  <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css">
   <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
   <div class="script-example">
     <script>
@@ -196,8 +196,8 @@ An example of the TileJSON representation of the map is:
 <section id="mapbox-api">
   <h2>MapBox GL</h2>
   <div id="mapboxgl-alternative-layers" style="width: 600px; height: 450px;"></div>
-  <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css' rel='stylesheet' />
-  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js'></script>
+  <link rel="stylesheet" href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css">
+  <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <div class="script-example">
     <script>
       mapboxgl.accessToken = m4h.keys.mapboxGL;

--- a/examples/set-view-zoom.html
+++ b/examples/set-view-zoom.html
@@ -135,7 +135,7 @@
     </ol>
     <div id="openlayers-map"></div>
   </div>
-  <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css" type="text/css">
+  <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css">
   <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
   <div class="script-example">
     <script>
@@ -407,8 +407,8 @@
     </ol>
     <div id="mapbox-api-map"></div>
   </div>
-  <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css' rel='stylesheet' />
-  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js'></script>
+  <link rel="stylesheet" href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css">
+  <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <div class="script-example">
     <script>
       {
@@ -463,9 +463,9 @@
     </ol>
     <div id="tomtom-map"></div>
   </div>
-  <script src='https://api.tomtom.com/maps-sdk-js/4.47.6/examples/sdk/tomtom.min.js'></script>
-  <!--<link rel='stylesheet' href='https://api.tomtom.com/maps-sdk-js/4.47.6/examples/sdk/map.css'>-->
-  <link rel='stylesheet' href='https://api.tomtom.com/maps-sdk-js/4.47.6/examples/elements.css'>
+  <script src="https://api.tomtom.com/maps-sdk-js/4.47.6/examples/sdk/tomtom.min.js"></script>
+  <!--<link rel="stylesheet" href="https://api.tomtom.com/maps-sdk-js/4.47.6/examples/sdk/map.css">-->
+  <link rel="stylesheet" href="https://api.tomtom.com/maps-sdk-js/4.47.6/examples/elements.css">
   <div class="script-example">
     <script>
       {

--- a/examples/single-location.html
+++ b/examples/single-location.html
@@ -101,7 +101,7 @@ for how to add point markers with the other services (where possible).
 <section id="mapbox-embed">
   <h2>MapBox Studio embed</h2>
   <div>
-    <iframe width="500" height="400"
+    <iframe width="600" height="450"
       src="https://api.mapbox.com/styles/v1/nchan0154/cjx9tt51t2d7d1dl7z92tnjks.html?fresh=true&access_token=pk.eyJ1IjoibmNoYW4wMTU0IiwiYSI6ImNqeDlzd3BrNjAxcjAzeXFuMjdodGowbnMifQ.wmDpzNGfADuQOSn1dABh7A#12.9/46.234099/6.055079/0">
     </iframe>
   </div>
@@ -135,7 +135,7 @@ for how to add point markers with the other services (where possible).
 <section id="openlayers">
   <h2>OpenLayers (with OpenStreetMap tiles)</h2>
   <div id="openlayers-map" style="width: 600px; height: 450px;"></div>
-  <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css" type="text/css">
+  <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css">
   <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
   <div class="script-example">
     <script>
@@ -277,8 +277,8 @@ for how to add point markers with the other services (where possible).
 <section id="mapbox-api">
   <h2>Mapbox GL JS API</h2>
   <div id="mapbox-api-map" style="width: 600px; height: 450px;"></div>
-  <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css' rel='stylesheet' />
-  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js'></script>
+  <link rel="stylesheet" href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css">
+  <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <div class="script-example">
     <script>
       { // block to restrict let and const scope to this example
@@ -303,9 +303,9 @@ for how to add point markers with the other services (where possible).
 <section id="tomtom">
   <h2>TomTom Maps SDK for Web with vector maps</h2>
   <div id="tomtom-single-location" style="width: 600px; height: 450px;"></div>
-  <script src='https://api.tomtom.com/maps-sdk-js/4.47.6/examples/sdk/tomtom.min.js'></script>
-  <!--<link rel='stylesheet' href='https://api.tomtom.com/maps-sdk-js/4.47.6/examples/sdk/map.css'>-->
-  <link rel='stylesheet' href='https://api.tomtom.com/maps-sdk-js/4.47.6/examples/elements.css'>
+  <script src="https://api.tomtom.com/maps-sdk-js/4.47.6/examples/sdk/tomtom.min.js"></script>
+  <!--<link rel="stylesheet" href="https://api.tomtom.com/maps-sdk-js/4.47.6/examples/sdk/map.css">-->
+  <link rel="stylesheet" href="https://api.tomtom.com/maps-sdk-js/4.47.6/examples/elements.css">
   <div class="script-example">
     <script>
       {

--- a/examples/technical-drawings.html
+++ b/examples/technical-drawings.html
@@ -98,7 +98,7 @@
 <section id="openlayers">
   <h2>OpenLayers with OpenStreetMap tiles</h2>
   <div id="openlayers-map" style="width: 600px; height: 450px;"></div>
-  <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css" type="text/css">
+  <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css">
   <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
   <div class="script-example">
     <script>
@@ -163,8 +163,8 @@
 <section id="mapbox-api">
   <h2>Mapbox GL JS API</h2>
   <div id="mapbox-api-map" style="width: 600px; height: 450px;"></div>
-  <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css' rel='stylesheet' />
-  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js'></script>
+  <link rel="stylesheet" href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css">
+  <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"></script>
   <div class="script-example">
     <script>
       { // block to restrict let and const scope to this example


### PR DESCRIPTION
Edit: Closing to submit separate PRs for unrelated changes.

My brain doesn't like single quotes and superfluous attributes (`type="text/css"` for `<link rel="stylesheet">`).

Apart from that, OpenLayers was missing its stylesheet in the [alternative-layers.html](https://maps4html.github.io/HTML-Map-Element-UseCases-Requirements/examples/alternative-layers.html#openlayers) and [change-bearing-map.html](https://maps4html.github.io/HTML-Map-Element-UseCases-Requirements/examples/change-bearing-map.html#openlayers) example pages, resulting in missing attribution and map controls.

Also in https://github.com/Maps4HTML/HTML-Map-Element-UseCases-Requirements/pull/176 I had somehow missed changing the width/height attrs for the [mapbox embed in the single-location.html example](https://maps4html.github.io/HTML-Map-Element-UseCases-Requirements/examples/single-location.html#mapbox-embed) to align with the dimensions of the other iframes/js implementations, so changing that now.
<!--
My apologies for doing unrelated things in one PR. I will make sure it doesn't happen again.

If it helps in reviewing, here's an overview of what I changed, and where:

> My brain doesn't like single quotes and superfluous attributes (`type="text/css"` for `<link rel="stylesheet">`).

This affects all changed files in this PR.

<hr>

> [...] OpenLayers was missing its stylesheet [...] resulting in missing attribution and map controls.

Added stylesheets in:

- [#diff-c1f61e153e777901236a48128adc9354R117](https://github.com/Maps4HTML/HTML-Map-Element-UseCases-Requirements/pull/184/files#diff-c1f61e153e777901236a48128adc9354R117)
- [#diff-e71d9d2e00b77debe4d9dd4ffa7236c0R83](https://github.com/Maps4HTML/HTML-Map-Element-UseCases-Requirements/pull/184/files#diff-e71d9d2e00b77debe4d9dd4ffa7236c0R83)

<hr>

> [...] I had somehow missed changing the width/height attrs for the mapbox embed [...]

Changed iframe `width` &plus; `height` in:

- [#diff-13261061bc510bd98aa4d44b4ed10705R104](https://github.com/Maps4HTML/HTML-Map-Element-UseCases-Requirements/pull/184/files#diff-13261061bc510bd98aa4d44b4ed10705L104-R104)
-->