### PR TITLE
Add missing stylesheet for OpenLayers

### DIFF
--- a/examples/alternative-layers.html
+++ b/examples/alternative-layers.html
@@ -114,6 +114,7 @@ but may or may not provide a standard control enabling users to choose among the
 <section id="openlayers">
   <h2>OpenLayers with OpenStreetMap tiles</h2>
   <div id="openlayers-map" style="width: 600px; height: 450px;"></div>
+  <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css" type="text/css">
   <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
   <div class="script-example">
     <script>

--- a/examples/change-bearing-map.html
+++ b/examples/change-bearing-map.html
@@ -80,6 +80,7 @@ to demonstrate that the map view can be dynamically updated in this respect.
 <section id="openlayers">
   <h2>OpenLayers with OpenStreetMap tiles</h2>
   <div id="ol-osm-use-case-change-bearing-map" style="width: 600px; height: 450px;"></div>
+  <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css" type="text/css">
   <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
   <div class="script-example">
     <script>


### PR DESCRIPTION
Add the CSS that is currently included in all the OpenLayers examples but is missing in the alternative-layers.html and change-bearing-map.html example pages, resulting in missing attribution and map controls.