### PR TITLE
Fix mapbox iframe width & height (examples/single-location.html)

### DIFF
--- a/examples/single-location.html
+++ b/examples/single-location.html
@@ -101,7 +101,7 @@ for how to add point markers with the other services (where possible).
 <section id="mapbox-embed">
   <h2>MapBox Studio embed</h2>
   <div>
-    <iframe width="500" height="400"
+    <iframe width="600" height="450"
       src="https://api.mapbox.com/styles/v1/nchan0154/cjx9tt51t2d7d1dl7z92tnjks.html?fresh=true&access_token=pk.eyJ1IjoibmNoYW4wMTU0IiwiYSI6ImNqeDlzd3BrNjAxcjAzeXFuMjdodGowbnMifQ.wmDpzNGfADuQOSn1dABh7A#12.9/46.234099/6.055079/0">
     </iframe>
   </div>


### PR DESCRIPTION
In #176 I had missed changing the width/height attrs for the mapbox embed in the single-location.html example to align with the dimensions of the other iframes/js implementations, so changing that now.