### PR TITLE
Add responsiveness to static maps examples

### DIFF
--- a/examples/examples.css
+++ b/examples/examples.css
@@ -10,8 +10,7 @@ html {
   overflow-x: hidden;
 }
 
-html,
-.script-example::before {
+html {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
@@ -38,7 +37,8 @@ h1 a:link, h1 a:visited {
   margin-bottom: 1rem;
 }
 
-.script-example code,
+.html-example > code,
+.script-example > code,
 .script-example script {
   display: block;
   white-space: pre;
@@ -48,21 +48,33 @@ h1 a:link, h1 a:visited {
   overflow-x: auto;
 }
 
+.html-example,
 .script-example {
   border: 1px solid #ccc;
   border-radius: 2px;
   margin-top: 1rem;
 }
 
+.html-example::before,
 .script-example::before {
-  content: 'Script';
   background-color: #efefef;
   position: relative;
   top: -0.5rem;
   left: 1.5rem;
   border: 1px solid #ccc;
   z-index: 2;
+  padding: 0.5rem;
+}
+
+.html-example {
   padding: 0.1rem 0.5rem;
+}
+
+.html-example::before {
+  content: 'HTML';
+}
+.script-example::before {
+  content: 'Script';
 }
 
 .map-container {
@@ -217,7 +229,8 @@ a[data-type='point']::before {
     min-height: 2rem;
 }
 
-button {
+button,
+summary {
   cursor: pointer;
 }
 
@@ -261,6 +274,10 @@ iframe,
   .custom-control.lat-lng {
     max-width: 200px;
   }
+
+  .static-streetview {
+    width: 100px;
+  }
 }
 
 @media (min-width: 430px) {
@@ -274,21 +291,20 @@ iframe,
 
 .static-embed {
     position: relative;
-    width: 600px;
-    height: 480px;
 }
 
 .static-embed img {
-    position: absolute;
-    z-index: 0;
+    max-width: 100%;
+    height: auto;
 }
 
-.static-embed .static-streetview {
+.static-streetview {
     z-index: 1;
-    bottom: 24px;
+    bottom: 2rem;
     left: 8px;
     border: 4px solid #bbb;
     border-radius: 4px;
+    position: absolute;
 }
 
 .popup.openlayers {

--- a/examples/static-map.html
+++ b/examples/static-map.html
@@ -33,7 +33,7 @@ Static map APIs allow a non-interactive map to be embedded in a webpage as an im
 
 <section id="google-maps">
   <h2>Google Static Maps &amp; Static Street View images</h2>
-  <div class="script-example">
+  <div class="html-example">
     <br>
     Map:
     <br>
@@ -52,7 +52,7 @@ Static map APIs allow a non-interactive map to be embedded in a webpage as an im
           const location = '51.4082343,30.0558434';
           const staticMapURL = `https://maps.googleapis.com/maps/api/staticmap?center=${location}&zoom=16&size=640x480&markers=color:red|location:51.408365,30.055867&key=${m4h.keys.google}`;
           const mapEmbedElement = document.querySelector('#google-maps .static-embed');
-          const mapCodeElement = document.querySelectorAll('#google-maps .script-example code');
+          const mapCodeElement = document.querySelectorAll('#google-maps .html-example code');
           const staticMap = document.createElement('img');
           staticMap.src = staticMapURL;
           staticMap.alt = 'Pripyat Amusement Park';
@@ -73,7 +73,7 @@ Static map APIs allow a non-interactive map to be embedded in a webpage as an im
 
 <section id="bing-maps">
   <h2>Bing Static Map image</h2>
-  <div class="script-example">
+  <div class="html-example">
     <br>
     Map:
     <br>
@@ -88,7 +88,7 @@ Static map APIs allow a non-interactive map to be embedded in a webpage as an im
           const location = '51.4082343,30.0558434';
           const staticMapURL = `https://dev.virtualearth.net/REST/v1/Imagery/Map/Road/${location}/16?mapSize=640,480&pushpin=51.408365,30.055867;0;&format=png&key=${m4h.keys.bing}`;
           const mapEmbedElement = document.querySelector('#bing-maps .static-embed');
-          const mapCodeElement = document.querySelectorAll('#bing-maps .script-example code');
+          const mapCodeElement = document.querySelectorAll('#bing-maps .html-example code');
           const staticMap = document.createElement('img');
           staticMap.src = staticMapURL;
           staticMap.alt = 'Pripyat Amusement Park';
@@ -101,7 +101,7 @@ Static map APIs allow a non-interactive map to be embedded in a webpage as an im
 
 <section id="mapbox">
   <h2>MapBox Static Map image</h2>
-  <div class="script-example">
+  <div class="html-example">
     <br>
     Map:
     <br>
@@ -116,7 +116,7 @@ Static map APIs allow a non-interactive map to be embedded in a webpage as an im
           const location = ['51.4082343','30.0558434'];
           const staticMapURL = `https://api.mapbox.com/styles/v1/mapbox/light-v9/static/pin-s+f00(30.055867,51.408365)/${location[1]},${location[0]},15,0,0/640x480?access_token=pk.eyJ1Ijoibmlja2ZpdHoiLCJhIjoiY2p3d2g3N2F5MDZ4azQwcG12dWticDB0diJ9.qnQV5QgYN_eDwg4uUdbO6Q`;
           const mapEmbedElement = document.querySelector('#mapbox .static-embed');
-          const mapCodeElement = document.querySelectorAll('#mapbox .script-example code');
+          const mapCodeElement = document.querySelectorAll('#mapbox .html-example code');
           const staticMap = document.createElement('img');
           staticMap.src = staticMapURL;
           staticMap.alt = 'Pripyat Amusement Park';
@@ -129,7 +129,7 @@ Static map APIs allow a non-interactive map to be embedded in a webpage as an im
 
 <section id="mapkit">
   <h2>MapKit Snapshot image</h2>
-  <div class="script-example">
+  <div class="html-example">
     <br>
     Map:
     <br>
@@ -149,7 +149,7 @@ Static map APIs allow a non-interactive map to be embedded in a webpage as an im
           const { referer, teamId, keyId, signature} = mapkitAuth;
           const staticMapURL = `https://snapshot.apple-mapkit.com/api/v1/snapshot?center=${location}&z=16&size=640x480&referer=${referer}&teamId=${teamId}&keyId=${keyId}&signature=${signature}`;
           const mapEmbedElement = document.querySelector('#mapkit .static-embed');
-          const mapCodeElement = document.querySelectorAll('#mapkit .script-example code');
+          const mapCodeElement = document.querySelectorAll('#mapkit .html-example code');
           const staticMap = document.createElement('img');
           staticMap.src = staticMapURL;
           staticMap.alt = 'Pripyat Amusement Park';
@@ -162,7 +162,7 @@ Static map APIs allow a non-interactive map to be embedded in a webpage as an im
 
 <section id="tomtom">
   <h2>TomTom Static Map image</h2>
-  <div class="script-example">
+  <div class="html-example">
     <br>
     Map:
     <br>
@@ -177,7 +177,7 @@ Static map APIs allow a non-interactive map to be embedded in a webpage as an im
           const location = '30.0558434,51.4082343';
           const staticMapURL = `https://api.tomtom.com/map/1/staticimage?center=${location}&zoom=15&width=640&height=480&layer=basic&style=main&format=png&view=Unified&key=${m4h.keys.tomtom}`;
           const mapEmbedElement = document.querySelector('#tomtom .static-embed');
-          const mapCodeElement = document.querySelectorAll('#tomtom .script-example code');
+          const mapCodeElement = document.querySelectorAll('#tomtom .html-example code');
           const staticMap = document.createElement('img');
           staticMap.src = staticMapURL;
           staticMap.alt = 'Pripyat Amusement Park';


### PR DESCRIPTION
Additional CSS is needed to make the recent addition of static maps responsive (to align with other example pages).

Also since this page uses HTML markup in examples this adds a new `.html-example` class with a content label of "HTML" as opposed to this:

```
.script-example::before {
  content: 'Script';
```

for HTML markup examples.