### PR TITLE
Change tiles source (CORS issue fix)

### DIFF
--- a/examples/custom-map.html
+++ b/examples/custom-map.html
@@ -32,7 +32,7 @@ The TileJSON representation of the map, as a JavaScript object, is:
       "attribution": "Presidential Mississippi River Commission, 1944. Public Domain.",
       "scheme": "tms",
       "tiles": [
-        "https://maps4html.github.io/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{-y}.png"
+        "https://maps4html.org/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{-y}.png"
       ],
       "bounds": [-92.60431421311640, 28.79036396296392, -88.72531489137181, 31.04551669046586],
       "minzoom": 6,
@@ -96,7 +96,7 @@ The TileJSON representation of the map, as a JavaScript object, is:
     <script>
       {
         const map = L.map('leaflet-js-map').setView([29.91794032671489, -90.664814552244105], 8);
-        L.tileLayer('https://maps4html.github.io/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{y}.png', {
+        L.tileLayer('https://maps4html.org/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{y}.png', {
           tms: true,
           minZoom: 6,
           maxZoom: 12,
@@ -162,7 +162,7 @@ The TileJSON representation of the map, as a JavaScript object, is:
   <div class="script-example">
     <script>
       function initMap() {
-        const TILE_URL = 'https://maps4html.github.io/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{y}.png';
+        const TILE_URL = 'https://maps4html.org/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{y}.png';
         const layerID = 'fisk_map';
         // Create a new ImageMapType layer.
         const layer = new google.maps.ImageMapType({
@@ -204,7 +204,7 @@ The TileJSON representation of the map, as a JavaScript object, is:
   <div class="script-example">
     <script>
       function initBingMap() {
-        const TILE_URL = 'https://maps4html.github.io/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{y}.png';
+        const TILE_URL = 'https://maps4html.org/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{y}.png';
         const layerID = 'fisk_map';
         // Create a new ImageMapType layer.
         const tileSource = new Microsoft.Maps.TileSource({
@@ -253,7 +253,7 @@ The TileJSON representation of the map, as a JavaScript object, is:
   <div class="script-example">
     <script>
       {
-        const TILE_URL = 'https://maps4html.github.io/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{y}.png';
+        const TILE_URL = 'https://maps4html.org/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{y}.png';
         mapkit.addEventListener('error', function(err) {
           console.log(err);
         });
@@ -313,7 +313,7 @@ The TileJSON representation of the map, as a JavaScript object, is:
               "raster-tiles": {
                 "type": "raster",
                 "scheme": m4h.fiskMapJSON.scheme,
-                "tiles": ['https://maps4html.github.io/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{y}.png'],
+                "tiles": ['https://maps4html.org/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{y}.png'],
                 "tileSize": 256,
                 "bounds": m4h.fiskMapJSON.bounds,
                 "attribution": m4h.fiskMapJSON.attribution

--- a/examples/data/fisk-maps.js
+++ b/examples/data/fisk-maps.js
@@ -12,7 +12,7 @@ m4h.fiskMaps = {
           "attribution": "Presidential Mississippi River Commission, 1944. Public Domain.",
           "scheme": "tms",
           "tiles": [
-            "https://maps4html.github.io/FiskMississippiMapsStreamCourses/sheet01/{z}/{x}/{-y}.png"
+            "https://maps4html.org/FiskMississippiMapsStreamCourses/sheet01/{z}/{x}/{-y}.png"
           ],
           "bounds": [-92.73821874999945, 35.15156827115307, -88.58807837153826, 37.38372501845145],
           "minzoom": 6,
@@ -28,7 +28,7 @@ m4h.fiskMaps = {
           "attribution": "Presidential Mississippi River Commission, 1944. Public Domain.",
           "scheme": "tms",
           "tiles": [
-            "https://maps4html.github.io/FiskMississippiMapsStreamCourses/sheet02/{z}/{x}/{-y}.png"
+            "https://maps4html.org/FiskMississippiMapsStreamCourses/sheet02/{z}/{x}/{-y}.png"
           ],
           "bounds": [-92.70756545472462, 33.02407078465588, -88.65406790680284, 35.27414929261117],
           "minzoom": 6,
@@ -44,7 +44,7 @@ m4h.fiskMaps = {
           "attribution": "Presidential Mississippi River Commission, 1944. Public Domain.",
           "scheme": "tms",
           "tiles": [
-            "https://maps4html.github.io/FiskMississippiMapsStreamCourses/sheet03/{z}/{x}/{-y}.png"
+            "https://maps4html.org/FiskMississippiMapsStreamCourses/sheet03/{z}/{x}/{-y}.png"
           ],
           "bounds": [-92.64710999091871, 30.90807578948790, -88.67752165286296, 33.17549574297950],
           "minzoom": 6,
@@ -60,7 +60,7 @@ m4h.fiskMaps = {
           "attribution": "Presidential Mississippi River Commission, 1944. Public Domain.",
           "scheme": "tms",
           "tiles": [
-            "https://maps4html.github.io/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{-y}.png"
+            "https://maps4html.org/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{-y}.png"
           ],
           "bounds": [-92.60431421311640, 28.79036396296392, -88.72531489137181, 31.04551669046586],
           "minzoom": 6,

--- a/examples/set-layer-visibility.html
+++ b/examples/set-layer-visibility.html
@@ -33,7 +33,7 @@ An example of the TileJSON representation of the map is:
       "attribution": "Presidential Mississippi River Commission, 1944. Public Domain.",
       "scheme": "tms",
       "tiles": [
-        "https://maps4html.github.io/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{-y}.png"
+        "https://maps4html.org/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{-y}.png"
       ],
       "bounds": [-92.60431421311640, 28.79036396296392, -88.72531489137181, 31.04551669046586],
       "minzoom": 6,

--- a/examples/technical-drawings.html
+++ b/examples/technical-drawings.html
@@ -85,7 +85,7 @@
     <script>
     {
       const map = L.map('leaflet-js-map').setView([0,0], 1);
-      L.tileLayer('https://maps4html.github.io/TiledArt-Rousseau/TheBanksOfTheBièvreNearBicêtre/{z}/{x}/{-y}.png', {
+      L.tileLayer('https://maps4html.org/TiledArt-Rousseau/TheBanksOfTheBièvreNearBicêtre/{z}/{x}/{-y}.png', {
         minZoom: 0,
         maxZoom: 4,
         attribution: 'Henri Rousseau: The Banks Of The Bièvre Near Bicêtre'
@@ -105,7 +105,7 @@
     const map = (() => {
       const pictureLayer = new ol.layer.Tile({
         source: new ol.source.TileJSON({
-          url: 'https://maps4html.github.io/TiledArt-Rousseau/TheBanksOfTheBièvreNearBicêtre/tiles.json',
+          url: 'https://maps4html.org/TiledArt-Rousseau/TheBanksOfTheBièvreNearBicêtre/tiles.json',
         })
       });
 
@@ -179,7 +179,7 @@
               "raster-tiles": {
                 "type": "raster",
                 "scheme": "tms",
-                "tiles": ["https://maps4html.github.io/TiledArt-Rousseau/TheBanksOfTheBièvreNearBicêtre/{z}/{x}/{y}.png"],
+                "tiles": ["https://maps4html.org/TiledArt-Rousseau/TheBanksOfTheBièvreNearBicêtre/{z}/{x}/{y}.png"],
                 "tileSize": 256,
                 "attribution": 'Henri Rousseau: The Banks Of The Bièvre Near Bicêtre'
               }


### PR DESCRIPTION
This PR changes the remaining references of `maps4html.github.io` to `maps4html.org` in the example pages, fixes CORS issues:

![cors-issue](https://user-images.githubusercontent.com/26493779/80709173-26240b00-8aed-11ea-96cd-127cab2b8df2.png)
