### PR TITLE
Update code blocks for the example pages

### DIFF
--- a/examples/add-custom-control.html
+++ b/examples/add-custom-control.html
@@ -74,7 +74,7 @@
   <script src="https://unpkg.com/leaflet@1.5.1/dist/leaflet.js"
           integrity="sha512-GffPMF3RvMeYyc1LWMHtK8EbPv0iNZ8/oTtHPx9/cc2ILxQ+u905qIwdpULaqDkyBKgOaB57QTMg7ztg8Jm2Og=="
           crossorigin=""></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       { // block to restrict let and const scope to this example
           // create the map
@@ -138,7 +138,7 @@
           L.Control.latLonControl({ position: 'bottomleft' }).addTo(map);
         }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="openlayers">
@@ -146,7 +146,7 @@
   <div id="openlayers-map" style="width: 600px; height: 450px;"></div>
   <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css" type="text/css">
   <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       { // block to restrict let and const scope to this example
           // set up the map
@@ -229,7 +229,7 @@
           map.addControl(openLayersLatLngControl);
         }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="google-maps-api">
@@ -241,7 +241,7 @@
       scriptElement.setAttribute('src', apiUrl);
       document.body.appendChild(scriptElement);
   </script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
         function initMap() {
             // set up the map
@@ -300,7 +300,7 @@
             map.controls[google.maps.ControlPosition.BOTTOM_RIGHT].push(latLonContainer);
         }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="bing-maps-api">
@@ -312,7 +312,7 @@
       bingScriptElement.setAttribute('src', bingApiUrl);
       document.body.appendChild(bingScriptElement);
   </script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
         function initBingMap() {
             // set up the map
@@ -375,7 +375,7 @@
             map.layers.insert(new BingLatLonControl());
         }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="mapkit-js">
@@ -388,7 +388,7 @@
   <div id="mapbox-api-map" style="width: 600px; height: 450px;"></div>
   <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css' rel='stylesheet' />
   <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js'></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
         { // block to restrict let and const scope to this example
             // set up map
@@ -451,14 +451,14 @@
             map.addControl(mapboxglLatLngControl);
         }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="tomtom">
   <h2>TomTom Maps SDK for Web with vector maps</h2>
 
 ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -467,7 +467,7 @@ or <p>Not applicable</p>
   <h2>D3 Geographies APIs</h2>
 
 ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>

--- a/examples/alternative-layers.html
+++ b/examples/alternative-layers.html
@@ -85,7 +85,7 @@ but may or may not provide a standard control enabling users to choose among the
   <script src="https://unpkg.com/leaflet@1.5.1/dist/leaflet.js"
           integrity="sha512-GffPMF3RvMeYyc1LWMHtK8EbPv0iNZ8/oTtHPx9/cc2ILxQ+u905qIwdpULaqDkyBKgOaB57QTMg7ztg8Jm2Og=="
           crossorigin=""></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       {
         const map = L.map('leaflet-map').setView([46.233226, 6.055737], 15);
@@ -109,7 +109,7 @@ but may or may not provide a standard control enabling users to choose among the
         }).addTo(map);
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="openlayers">
@@ -117,7 +117,7 @@ but may or may not provide a standard control enabling users to choose among the
   <div id="openlayers-map" style="width: 600px; height: 450px;"></div>
   <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css" type="text/css">
   <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       {
         let map = new ol.Map({
@@ -159,7 +159,7 @@ but may or may not provide a standard control enabling users to choose among the
         map.addControl(openLayersLayerControl);
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="google-maps-api">
@@ -171,7 +171,7 @@ but may or may not provide a standard control enabling users to choose among the
     scriptElement.setAttribute('src', apiUrl);
     document.body.appendChild(scriptElement);
   </script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       function initMap() {
         const map = new google.maps.Map(
@@ -186,7 +186,7 @@ but may or may not provide a standard control enabling users to choose among the
         );
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="bing-maps-api">
@@ -198,7 +198,7 @@ but may or may not provide a standard control enabling users to choose among the
     bingScriptElement.setAttribute('src', bingApiUrl);
     document.body.appendChild(bingScriptElement);
   </script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       function initBingMap() {
         let map = new Microsoft.Maps.Map(document.getElementById('bing-maps-api-map'), {
@@ -207,14 +207,14 @@ but may or may not provide a standard control enabling users to choose among the
         });
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="mapkit-js">
   <h2>MapKit JS (Apple Maps) API</h2>
   <div id="mapkit-js-map" style="width: 600px; height: 450px;"></div>
   <script src="https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.js"></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       mapkit.addEventListener('error', function(err) {
         console.log(err);
@@ -240,7 +240,7 @@ but may or may not provide a standard control enabling users to choose among the
         region: region
       });
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="mapbox-api">
@@ -248,7 +248,7 @@ but may or may not provide a standard control enabling users to choose among the
   <div id="mapbox-api-map" style="width: 600px; height: 450px;"></div>
   <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css' rel='stylesheet' />
   <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js'></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       {
         mapboxgl.accessToken = m4h.keys.mapboxGL;
@@ -297,14 +297,14 @@ but may or may not provide a standard control enabling users to choose among the
         map.getContainer().appendChild(mapboxglLayerControl.onAdd(map));
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="tomtom">
   <h2>TomTom Maps SDK for Web with vector maps</h2>
 
   ***TODO<!--
-  Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+  Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
   or <p>Not applicable</p>
   -->***
 </section>
@@ -313,7 +313,7 @@ but may or may not provide a standard control enabling users to choose among the
   <h2>D3 Geographies APIs</h2>
 
   ***TODO<!--
-  Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+  Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
   or <p>Not applicable</p>
   -->***
 </section>

--- a/examples/animate-view-change.html
+++ b/examples/animate-view-change.html
@@ -101,7 +101,7 @@ Other libraries require the developer to implement the sequencing of animations 
   </div>
   <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css" type="text/css">
   <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       {
         // convert values from DOM attributes to properties for animation
@@ -152,7 +152,7 @@ Other libraries require the developer to implement the sequencing of animations 
         });
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="google-maps-api">
@@ -184,7 +184,7 @@ Other libraries require the developer to implement the sequencing of animations 
   <h2>D3 Geographies APIs</h2>
 
   ***TODO<!--
-  Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+  Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
   or <p>Not applicable</p>
   -->***
 </section>

--- a/examples/change-bearing-map.html
+++ b/examples/change-bearing-map.html
@@ -83,7 +83,7 @@ to demonstrate that the map view can be dynamically updated in this respect.
   <div id="ol-osm-use-case-change-bearing-map" style="width: 600px; height: 450px;"></div>
   <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css" type="text/css">
   <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       {
         let map = new ol.Map({
@@ -101,7 +101,7 @@ to demonstrate that the map view can be dynamically updated in this respect.
         map.getView().setRotation(-45 * (Math.PI / 180));
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="google-maps-api">
@@ -118,7 +118,7 @@ to demonstrate that the map view can be dynamically updated in this respect.
   <h2>MapKit JS (Apple Maps) API</h2>
   <div id="mapkit-js-map" style="width: 600px; height: 450px;"></div>
   <script src="https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.js"></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       {
         let mapkitKey = m4h.keys.mapkit.maps4html;
@@ -144,7 +144,7 @@ to demonstrate that the map view can be dynamically updated in this respect.
         map.rotation = -45;
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="mapbox-api">
@@ -152,7 +152,7 @@ to demonstrate that the map view can be dynamically updated in this respect.
   <div id="mapbox-api-map" style="width: 600px; height: 450px;"></div>
   <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css' rel='stylesheet' />
   <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js'></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       {
         mapboxgl.accessToken = m4h.keys.mapboxGL;
@@ -165,7 +165,7 @@ to demonstrate that the map view can be dynamically updated in this respect.
         map.setBearing(45);
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="tomtom">
@@ -177,7 +177,7 @@ to demonstrate that the map view can be dynamically updated in this respect.
   <h2>D3 Geographies APIs</h2>
 
   ***TODO<!--
-  Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+  Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
   or <p>Not applicable</p>
   -->***
 </section>

--- a/examples/create-map.html
+++ b/examples/create-map.html
@@ -107,7 +107,7 @@ the examples in those cases use OpenStreetMap tiles.
   <script src="https://unpkg.com/leaflet@1.5.1/dist/leaflet.js"
           integrity="sha512-GffPMF3RvMeYyc1LWMHtK8EbPv0iNZ8/oTtHPx9/cc2ILxQ+u905qIwdpULaqDkyBKgOaB57QTMg7ztg8Jm2Og=="
           crossorigin=""></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       {
         const map = L.map('leaflet-js-map').setView([0,0], 0);
@@ -118,7 +118,7 @@ the examples in those cases use OpenStreetMap tiles.
         }).addTo(map);
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="openlayers">
@@ -126,7 +126,7 @@ the examples in those cases use OpenStreetMap tiles.
   <div id="openlayers-map" style="width: 600px; height: 450px;"></div>
   <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css" type="text/css">
   <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       {
         const map = new ol.Map({
@@ -143,7 +143,7 @@ the examples in those cases use OpenStreetMap tiles.
         });
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="google-maps-api">
@@ -155,7 +155,7 @@ the examples in those cases use OpenStreetMap tiles.
     scriptElement.setAttribute('src', apiUrl);
     document.body.appendChild(scriptElement);
   </script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       function initMap() {
           const map = new google.maps.Map(
@@ -170,7 +170,7 @@ the examples in those cases use OpenStreetMap tiles.
           );
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="bing-maps-api">
@@ -182,7 +182,7 @@ the examples in those cases use OpenStreetMap tiles.
     bingScriptElement.setAttribute('src', bingApiUrl);
     document.body.appendChild(bingScriptElement);
   </script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       function initBingMap() {
           const map = new Microsoft.Maps.Map(document.getElementById('bing-maps-api-map'), {
@@ -191,14 +191,14 @@ the examples in those cases use OpenStreetMap tiles.
           });
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="mapkit-js">
   <h2>MapKit JS (Apple Maps) API</h2>
   <div id="mapkit-js-map" style="width: 600px; height: 450px;"></div>
   <script src="https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.js"></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       {
         mapkit.addEventListener('error', function(err) {
@@ -226,7 +226,7 @@ the examples in those cases use OpenStreetMap tiles.
         });
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="mapbox-api">
@@ -234,7 +234,7 @@ the examples in those cases use OpenStreetMap tiles.
   <div id="mapbox-api-map" style="width: 600px; height: 450px;"></div>
   <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css' rel='stylesheet' />
   <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js'></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       {
         mapboxgl.accessToken = m4h.keys.mapboxGL;
@@ -245,7 +245,7 @@ the examples in those cases use OpenStreetMap tiles.
         });
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="tomtom">
@@ -255,7 +255,7 @@ the examples in those cases use OpenStreetMap tiles.
   <!--<link rel='stylesheet' href='https://api.tomtom.com/maps-sdk-js/4.47.6/examples/sdk/map.css'>-->
   <link rel='stylesheet' href='tomtom/maps-extract.css'>
   <link rel='stylesheet' href='https://api.tomtom.com/maps-sdk-js/4.47.6/examples/elements.css'>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       {
         tomtom.setProductInfo('Maps4HTML Examples', '4.47.6');
@@ -268,14 +268,14 @@ the examples in those cases use OpenStreetMap tiles.
         });
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="d3-geo">
   <h2>D3 Geographies APIs</h2>
   <div id="d3-geo-map" class="d3-geo-map" style="width: 600px; height: 450px;"></div>
   <script src="https://d3js.org/d3.v5.js"></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
         {
             const handleZoom = () => {
@@ -349,7 +349,7 @@ the examples in those cases use OpenStreetMap tiles.
             });
         }
     </script>
-  </div>
+  </code>
 </section>
 </body>
 </html>

--- a/examples/custom-map.html
+++ b/examples/custom-map.html
@@ -24,8 +24,8 @@ The map used here is sheet 4 of plate 15 of the report.
 The TileJSON representation of the map, as a JavaScript object, is:
 </p>
 
-<div class="script-example">
-  <script>
+<code>
+  <pre>
     m4h.fiskMapJSON = {
       "tilejson": "2.2.0",
       "name": "Mississippi Stream Courses sheet 4 - Harold Fisk, US Army Corps of Engineers",
@@ -38,8 +38,8 @@ The TileJSON representation of the map, as a JavaScript object, is:
       "minzoom": 6,
       "maxzoom": 12
     };
-  </script>
-</div>
+  </pre>
+</code>
 
 <details>
   <summary>Jump to section…</summary>
@@ -92,7 +92,7 @@ The TileJSON representation of the map, as a JavaScript object, is:
   <script src="https://unpkg.com/leaflet@1.5.1/dist/leaflet.js"
           integrity="sha512-GffPMF3RvMeYyc1LWMHtK8EbPv0iNZ8/oTtHPx9/cc2ILxQ+u905qIwdpULaqDkyBKgOaB57QTMg7ztg8Jm2Og=="
           crossorigin=""></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       {
         const map = L.map('leaflet-js-map').setView([29.91794032671489, -90.664814552244105], 8);
@@ -104,7 +104,7 @@ The TileJSON representation of the map, as a JavaScript object, is:
         }).addTo(map);
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="openlayers">
@@ -112,7 +112,7 @@ The TileJSON representation of the map, as a JavaScript object, is:
   <div id="openlayers-map" style="width: 600px; height: 450px; background-color: #ccc;"></div>
   <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css" type="text/css">
   <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       {
         const map = (() => {
@@ -146,7 +146,7 @@ The TileJSON representation of the map, as a JavaScript object, is:
         })();
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="google-maps-api">
@@ -159,7 +159,7 @@ The TileJSON representation of the map, as a JavaScript object, is:
     document.body.appendChild(scriptElement);
   </script>
 
-  <div class="script-example">
+  <code class="script-example">
     <script>
       function initMap() {
         const TILE_URL = 'https://maps4html.github.io/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{y}.png';
@@ -189,7 +189,7 @@ The TileJSON representation of the map, as a JavaScript object, is:
         map.setMapTypeId(layerID);
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="bing-maps-api">
@@ -201,7 +201,7 @@ The TileJSON representation of the map, as a JavaScript object, is:
     bingScriptElement.setAttribute('src', bingApiUrl);
     document.body.appendChild(bingScriptElement);
   </script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       function initBingMap() {
         const TILE_URL = 'https://maps4html.github.io/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{y}.png';
@@ -239,7 +239,7 @@ The TileJSON representation of the map, as a JavaScript object, is:
         map.layers.insert(layer);
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="mapkit-js">
@@ -250,7 +250,7 @@ The TileJSON representation of the map, as a JavaScript object, is:
   </p>
   <div id="mapkit-js-map" style="width: 600px; height: 450px;"></div>
   <script src="https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.js"></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       {
         const TILE_URL = 'https://maps4html.github.io/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{y}.png';
@@ -292,7 +292,7 @@ The TileJSON representation of the map, as a JavaScript object, is:
         map.tileOverlays = [tileOverlay];
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="mapbox-api">
@@ -300,7 +300,7 @@ The TileJSON representation of the map, as a JavaScript object, is:
   <div id="mapbox-api-map" style="width: 600px; height: 450px;"></div>
   <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css' rel='stylesheet' />
   <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js'></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       {
         mapboxgl.accessToken = m4h.keys.mapboxGL;
@@ -333,7 +333,7 @@ The TileJSON representation of the map, as a JavaScript object, is:
         map.addControl(new mapboxgl.NavigationControl());
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="tomtom">
@@ -345,7 +345,7 @@ The TileJSON representation of the map, as a JavaScript object, is:
   <h2>D3 Geographies APIs</h2>
 
   ***TODO<!--
-  Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+  Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
   or <p>Not applicable</p>
   -->***
 </section>

--- a/examples/custom-map.html
+++ b/examples/custom-map.html
@@ -24,21 +24,19 @@ The map used here is sheet 4 of plate 15 of the report.
 The TileJSON representation of the map, as a JavaScript object, is:
 </p>
 
-<code>
-  <pre>
-    m4h.fiskMapJSON = {
-      "tilejson": "2.2.0",
-      "name": "Mississippi Stream Courses sheet 4 - Harold Fisk, US Army Corps of Engineers",
-      "attribution": "Presidential Mississippi River Commission, 1944. Public Domain.",
-      "scheme": "tms",
-      "tiles": [
-        "https://maps4html.github.io/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{-y}.png"
-      ],
-      "bounds": [-92.60431421311640, 28.79036396296392, -88.72531489137181, 31.04551669046586],
-      "minzoom": 6,
-      "maxzoom": 12
-    };
-  </pre>
+<code class="script-example">
+  m4h.fiskMapJSON = {
+    "tilejson": "2.2.0",
+    "name": "Mississippi Stream Courses sheet 4 - Harold Fisk, US Army Corps of Engineers",
+    "attribution": "Presidential Mississippi River Commission, 1944. Public Domain.",
+    "scheme": "tms",
+    "tiles": [
+      "https://maps4html.github.io/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{-y}.png"
+    ],
+    "bounds": [-92.60431421311640, 28.79036396296392, -88.72531489137181, 31.04551669046586],
+    "minzoom": 6,
+    "maxzoom": 12
+  };
 </code>
 
 <details>

--- a/examples/custom-map.html
+++ b/examples/custom-map.html
@@ -25,18 +25,20 @@ The TileJSON representation of the map, as a JavaScript object, is:
 </p>
 
 <code class="script-example">
-  m4h.fiskMapJSON = {
-    "tilejson": "2.2.0",
-    "name": "Mississippi Stream Courses sheet 4 - Harold Fisk, US Army Corps of Engineers",
-    "attribution": "Presidential Mississippi River Commission, 1944. Public Domain.",
-    "scheme": "tms",
-    "tiles": [
-      "https://maps4html.github.io/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{-y}.png"
-    ],
-    "bounds": [-92.60431421311640, 28.79036396296392, -88.72531489137181, 31.04551669046586],
-    "minzoom": 6,
-    "maxzoom": 12
-  };
+  <script>
+    m4h.fiskMapJSON = {
+      "tilejson": "2.2.0",
+      "name": "Mississippi Stream Courses sheet 4 - Harold Fisk, US Army Corps of Engineers",
+      "attribution": "Presidential Mississippi River Commission, 1944. Public Domain.",
+      "scheme": "tms",
+      "tiles": [
+        "https://maps4html.github.io/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{-y}.png"
+      ],
+      "bounds": [-92.60431421311640, 28.79036396296392, -88.72531489137181, 31.04551669046586],
+      "minzoom": 6,
+      "maxzoom": 12
+    };
+  </script>
 </code>
 
 <details>

--- a/examples/example-template.html
+++ b/examples/example-template.html
@@ -76,7 +76,7 @@ Copy & paste embed code or <p>Not applicable</p>
   <h2>Leaflet.js (with OpenStreetMap tiles)</h2>
 
 ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -85,7 +85,7 @@ or <p>Not applicable</p>
   <h2>OpenLayers with OpenStreetMap tiles</h2>
 
 ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -94,7 +94,7 @@ or <p>Not applicable</p>
   <h2>Google Maps API</h2>
 
 ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -103,7 +103,7 @@ or <p>Not applicable</p>
   <h2>Bing Maps Control API</h2>
 
 ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -112,7 +112,7 @@ or <p>Not applicable</p>
   <h2>MapKit JS (Apple Maps) API</h2>
 
 ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -121,7 +121,7 @@ or <p>Not applicable</p>
   <h2>Mapbox GL JS API</h2>
 
 ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -130,7 +130,7 @@ or <p>Not applicable</p>
   <h2>TomTom Maps SDK for Web with vector maps</h2>
 
 ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -139,7 +139,7 @@ or <p>Not applicable</p>
   <h2>D3 Geographies APIs</h2>
 
 ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>

--- a/examples/examples.css
+++ b/examples/examples.css
@@ -509,3 +509,7 @@ svg .overlay.parish {
 .script-example::before {
   content: "Script";
 }
+
+pre {
+  overflow-x: auto;
+}

--- a/examples/examples.css
+++ b/examples/examples.css
@@ -10,7 +10,9 @@ html {
   overflow-x: hidden;
 }
 
-html {
+html,
+html ::before,
+html ::after {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
@@ -33,48 +35,12 @@ h1 a:link, h1 a:visited {
   color: navy;
 }
 
+h1 {
+  line-height: 1.3;
+}
+
 .toc > li {
   margin-bottom: 1rem;
-}
-
-.html-example > code,
-.script-example > code,
-.script-example script {
-  display: block;
-  white-space: pre;
-  font-family: monospace;
-  padding: 0 2rem 1rem 0;
-  z-index: 2;
-  overflow-x: auto;
-}
-
-.html-example,
-.script-example {
-  border: 1px solid #ccc;
-  border-radius: 2px;
-  margin-top: 1rem;
-}
-
-.html-example::before,
-.script-example::before {
-  background-color: #efefef;
-  position: relative;
-  top: -0.5rem;
-  left: 1.5rem;
-  border: 1px solid #ccc;
-  z-index: 2;
-  padding: 0.5rem;
-}
-
-.html-example {
-  padding: 0.1rem 0.5rem;
-}
-
-.html-example::before {
-  content: 'HTML';
-}
-.script-example::before {
-  content: 'Script';
 }
 
 .map-container {
@@ -294,6 +260,7 @@ iframe,
 
 .static-embed {
     position: relative;
+    margin-top: 1rem;
 }
 
 .static-embed img {
@@ -504,4 +471,44 @@ svg .overlay.parish {
     fill-opacity: 0.8;
     stroke: rgb(40,39,101);
 
+}
+
+/* Code examples */
+.html-example
+.script-example {
+  display: block;
+}
+
+.html-example,
+.script-example script {
+  background-color: #fcfcfc;
+  border-radius: 2px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  display: block;
+  margin-top: 1rem;
+  overflow-x: auto;
+  padding: 3rem 1rem 1rem;
+  position: relative;
+  white-space: pre;
+}
+
+.html-example::before,
+.script-example script::before {
+  display: block;
+  font-size: 1rem;
+  margin-top: .75rem;
+  position: absolute;
+  top: 0;
+}
+
+.html-example::before {
+  content: "HTML";
+}
+
+.script-example script::before {
+  content: "Script";
+}
+
+pre {
+  overflow-x: auto;
 }

--- a/examples/examples.css
+++ b/examples/examples.css
@@ -480,7 +480,6 @@ svg .overlay.parish {
   background-color: #fcfcfc;
   border-radius: 2px;
   box-shadow: 0 1px 3px rgba(0,0,0,0.2);
-  display: block;
   margin-top: 1rem;
   overflow-x: auto;
   position: relative;

--- a/examples/examples.css
+++ b/examples/examples.css
@@ -483,14 +483,20 @@ svg .overlay.parish {
   display: block;
   margin-top: 1rem;
   overflow-x: auto;
-  padding: 3rem 1rem 1rem;
   position: relative;
   white-space: pre;
 }
 
 .script-example script {
   display: block;
-  margin: -2rem 0 -2rem -1rem
+}
+
+.html-example {
+  padding: 3rem 1rem 1rem;
+}
+
+.script-example {
+  padding: 1rem 1rem 0;
 }
 
 .html-example::before,

--- a/examples/examples.css
+++ b/examples/examples.css
@@ -474,13 +474,9 @@ svg .overlay.parish {
 }
 
 /* Code examples */
-.html-example
+.html-example,
 .script-example {
   display: block;
-}
-
-.html-example,
-.script-example script {
   background-color: #fcfcfc;
   border-radius: 2px;
   box-shadow: 0 1px 3px rgba(0,0,0,0.2);
@@ -492,8 +488,13 @@ svg .overlay.parish {
   white-space: pre;
 }
 
+.script-example script {
+  display: block;
+  margin: -2rem 0 -2rem -1rem
+}
+
 .html-example::before,
-.script-example script::before {
+.script-example::before {
   display: block;
   font-size: 1rem;
   margin-top: .75rem;
@@ -505,10 +506,6 @@ svg .overlay.parish {
   content: "HTML";
 }
 
-.script-example script::before {
+.script-example::before {
   content: "Script";
-}
-
-pre {
-  overflow-x: auto;
 }

--- a/examples/generate-vector-features.html
+++ b/examples/generate-vector-features.html
@@ -76,7 +76,7 @@ Copy & paste embed code or <p>Not applicable</p>
   <h2>Leaflet.js (with OpenStreetMap tiles)</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -85,7 +85,7 @@ or <p>Not applicable</p>
   <h2>OpenLayers with OpenStreetMap tiles</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -94,7 +94,7 @@ or <p>Not applicable</p>
   <h2>Google Maps API</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -103,7 +103,7 @@ or <p>Not applicable</p>
   <h2>Bing Maps Control API</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -112,7 +112,7 @@ or <p>Not applicable</p>
   <h2>MapKit JS (Apple Maps) API</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -121,7 +121,7 @@ or <p>Not applicable</p>
   <h2>Mapbox GL JS API</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -130,7 +130,7 @@ or <p>Not applicable</p>
   <h2>TomTom Maps SDK for Web with vector maps</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -139,7 +139,7 @@ or <p>Not applicable</p>
   <h2>D3 Geographies APIs</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>

--- a/examples/heatmap.html
+++ b/examples/heatmap.html
@@ -76,7 +76,7 @@ Copy & paste embed code or <p>Not applicable</p>
   <h2>Leaflet.js (with OpenStreetMap tiles)</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -85,7 +85,7 @@ or <p>Not applicable</p>
   <h2>OpenLayers with OpenStreetMap tiles</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -94,7 +94,7 @@ or <p>Not applicable</p>
   <h2>Google Maps API</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -103,7 +103,7 @@ or <p>Not applicable</p>
   <h2>Bing Maps Control API</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -112,7 +112,7 @@ or <p>Not applicable</p>
   <h2>MapKit JS (Apple Maps) API</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -121,7 +121,7 @@ or <p>Not applicable</p>
   <h2>Mapbox GL JS API</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -130,7 +130,7 @@ or <p>Not applicable</p>
   <h2>TomTom Maps SDK for Web with vector maps</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -139,7 +139,7 @@ or <p>Not applicable</p>
   <h2>D3 Geographies APIs</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>

--- a/examples/html-annotations.html
+++ b/examples/html-annotations.html
@@ -69,7 +69,7 @@
   <script src="https://unpkg.com/leaflet@1.5.1/dist/leaflet.js"
           integrity="sha512-GffPMF3RvMeYyc1LWMHtK8EbPv0iNZ8/oTtHPx9/cc2ILxQ+u905qIwdpULaqDkyBKgOaB57QTMg7ztg8Jm2Og=="
           crossorigin=""></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
         {
             const map = L.map('leaflet-js-map').setView([46.233226, 6.055737], 15);
@@ -83,7 +83,7 @@
             centerMarker.bindPopup("<h3>CERN</h3><p>The World Wide Web was invented here by Sir Tim Berners-Lee between 1989 and 1991.</p>").openPopup();
         }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="openlayers">
@@ -91,7 +91,7 @@
   <div id="openlayers-map" style="width: 600px; height: 450px;"></div>
   <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css" type="text/css">
   <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
         {
             const vectorLayerFeatures = [];
@@ -169,7 +169,7 @@
             popup.setPosition(view.getCenter());
         }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="google-maps-api">
@@ -181,7 +181,7 @@
       scriptElement.setAttribute('src', apiUrl);
       document.body.appendChild(scriptElement);
   </script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
         function initMap() {
             // set up the map
@@ -207,7 +207,7 @@
             infoWindow.open(map, centerMarker);
         }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="bing-maps-api">
@@ -219,7 +219,7 @@
       bingScriptElement.setAttribute('src', bingApiUrl);
       document.body.appendChild(bingScriptElement);
   </script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
         function initBingMap() {
             // set up the map
@@ -245,14 +245,14 @@
             })
         }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="mapkit-js">
   <h2>MapKit JS (Apple Maps) API</h2>
   <div id="mapkit-js-map" style="width: 600px; height: 450px;"></div>
   <script src="https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.js"></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
         {
             mapkit.addEventListener('error', function(err) {
@@ -287,7 +287,7 @@
             map.addAnnotation(marker);
         }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="mapbox-api">
@@ -295,7 +295,7 @@
   <div id="mapbox-api-map" style="width: 600px; height: 450px;"></div>
   <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css' rel='stylesheet' />
   <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js'></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
         { // block to restrict let and const scope to this example
             // set up map
@@ -324,7 +324,7 @@
             centerMarker.setPopup(popup);
         }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="tomtom">
@@ -334,7 +334,7 @@
   <!--<link rel='stylesheet' href='https://api.tomtom.com/maps-sdk-js/4.47.6/examples/sdk/map.css'>-->
   <link rel='stylesheet' href='tomtom/maps-extract.css'>
   <link rel='stylesheet' href='https://api.tomtom.com/maps-sdk-js/4.47.6/examples/elements.css'>
-  <div class="script-example">
+  <code class="script-example">
     <script>
         {
             tomtom.setProductInfo('Maps4HTML Examples', '4.47.6');
@@ -350,14 +350,14 @@
             centerMarker.bindPopup("<h3>CERN</h3><p>The World Wide Web was invented here by Sir Tim Berners-Lee between 1989 and 1991.</p>").openPopup();
         }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="d3-geo">
   <h2>D3 Geographies APIs</h2>
 
 ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>

--- a/examples/layers.html
+++ b/examples/layers.html
@@ -78,7 +78,7 @@ Copy & paste embed code or <p>Not applicable</p>
   <h2>Leaflet.js (with OpenStreetMap tiles)</h2>
 
 ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -87,7 +87,7 @@ or <p>Not applicable</p>
   <h2>OpenLayers with OpenStreetMap tiles</h2>
 
 ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -96,7 +96,7 @@ or <p>Not applicable</p>
   <h2>Google Maps API</h2>
 
 ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -105,7 +105,7 @@ or <p>Not applicable</p>
   <h2>Bing Maps Control API</h2>
 
 ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -114,7 +114,7 @@ or <p>Not applicable</p>
   <h2>MapKit JS (Apple Maps) API</h2>
 
 ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -123,7 +123,7 @@ or <p>Not applicable</p>
   <h2>Mapbox GL JS API</h2>
 
 ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -132,7 +132,7 @@ or <p>Not applicable</p>
   <h2>TomTom Maps SDK for Web with vector maps</h2>
 
 ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -141,7 +141,7 @@ or <p>Not applicable</p>
   <h2>D3 Geographies APIs</h2>
 
 ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>

--- a/examples/multiple-location-markers.html
+++ b/examples/multiple-location-markers.html
@@ -80,7 +80,7 @@ Default marker icons are used where available.
     <script src="https://unpkg.com/leaflet@1.5.1/dist/leaflet.js"
             integrity="sha512-GffPMF3RvMeYyc1LWMHtK8EbPv0iNZ8/oTtHPx9/cc2ILxQ+u905qIwdpULaqDkyBKgOaB57QTMg7ztg8Jm2Og=="
             crossorigin=""></script>
-    <div class="script-example">
+    <code class="script-example">
       <script>
         {
             const map = L.map('leaflet-js-map').setView([46.231226, 6.051737], 14);
@@ -97,7 +97,7 @@ Default marker icons are used where available.
             leafletMarkers.addTo(map);
         }
       </script>
-    </div>
+    </code>
 </section>
 
 <section id="openlayers">
@@ -105,7 +105,7 @@ Default marker icons are used where available.
     <div id="openlayers-map" style="width: 600px; height: 450px;"></div>
     <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css" type="text/css">
     <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
-    <div class="script-example">
+    <code class="script-example">
       <script>
         {
             const markerSVGData = "data:image/svg+xml,%3Csvg width='36px' height='36px' viewBox='-18 -18 36 36' xmlns='http://www.w3.org/2000/svg'%3E%3Ctitle%3Eround-marker%3C/title%3E%3Cg stroke-width='3' stroke='%236af'%3E%3Ccircle fill='%23fc2' fill-opacity='0.7' r='16'/%3E%3Ccircle r='1.5'/%3E%3C/g%3E%3C/svg%3E";
@@ -150,7 +150,7 @@ Default marker icons are used where available.
             });
         }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="google-maps-api">
@@ -162,7 +162,7 @@ Default marker icons are used where available.
     scriptElement.setAttribute('src', apiUrl);
     document.body.appendChild(scriptElement);
   </script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       function initMap() {
           const map = new google.maps.Map(
@@ -188,7 +188,7 @@ Default marker icons are used where available.
           });
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="bing-maps-api">
@@ -200,7 +200,7 @@ Default marker icons are used where available.
       bingScriptElement.setAttribute('src', bingApiUrl);
       document.body.appendChild(bingScriptElement);
   </script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
         function initBingMap() {
             // set up the map
@@ -220,14 +220,14 @@ Default marker icons are used where available.
             });
         }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="mapkit-js">
   <h2>MapKit JS (Apple Maps) API</h2>
   <div id="mapkit-js-map" style="width: 600px; height: 450px;"></div>
   <script src="https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.js"></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       {
         mapkit.addEventListener('error', function(err) {
@@ -264,7 +264,7 @@ Default marker icons are used where available.
         });
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="mapbox-api">
@@ -272,7 +272,7 @@ Default marker icons are used where available.
   <div id="mapbox-api-map" style="width: 600px; height: 450px;"></div>
   <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css' rel='stylesheet' />
   <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js'></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       {
           mapboxgl.accessToken = m4h.keys.mapboxGL;
@@ -292,7 +292,7 @@ Default marker icons are used where available.
           });
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="tomtom">
@@ -302,7 +302,7 @@ Default marker icons are used where available.
   <!-- <link rel='stylesheet' href='https://api.tomtom.com/maps-sdk-js/4.47.6/examples/sdk/map.css'> -->
   <link rel='stylesheet' href='tomtom/maps-extract.css'>
   <link rel='stylesheet' href='https://api.tomtom.com/maps-sdk-js/4.47.6/examples/elements.css'>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       {
         tomtom.setProductInfo('Maps4HTML Examples', '4.47.6');
@@ -323,14 +323,14 @@ Default marker icons are used where available.
         });
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="d3-geo">
   <h2>D3 Geographies APIs</h2>
   <div id="d3-geo-map" class="d3-geo-map" style="width: 600px; height: 450px;"></div>
   <script src="https://d3js.org/d3.v5.js"></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
         {
             const handleZoom = () => {
@@ -430,7 +430,7 @@ Default marker icons are used where available.
             });
         }
     </script>
-  </div>
+  </code>
 </section>
 </body>
 </html>

--- a/examples/poly-features.html
+++ b/examples/poly-features.html
@@ -73,7 +73,7 @@ This was exported from OpenStreetMap data.
   <script src="https://unpkg.com/leaflet@1.5.1/dist/leaflet.js"
           integrity="sha512-GffPMF3RvMeYyc1LWMHtK8EbPv0iNZ8/oTtHPx9/cc2ILxQ+u905qIwdpULaqDkyBKgOaB57QTMg7ztg8Jm2Og=="
           crossorigin=""></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
         {
             const map = L.map('leaflet-js-map').setView([52.5548, -0.8971], 13);
@@ -92,7 +92,7 @@ This was exported from OpenStreetMap data.
             glooston.addTo(map);
         }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="openlayers">
@@ -100,7 +100,7 @@ This was exported from OpenStreetMap data.
   <div id="openlayers-map" style="width: 600px; height: 450px;"></div>
   <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css" type="text/css">
   <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
         {
             const vectorSource = new ol.source.Vector({
@@ -136,7 +136,7 @@ This was exported from OpenStreetMap data.
             });
         }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="google-maps-api">
@@ -148,7 +148,7 @@ This was exported from OpenStreetMap data.
       scriptElement.setAttribute('src', apiUrl);
       document.body.appendChild(scriptElement);
   </script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
         function initMap() {
             const map = new google.maps.Map(
@@ -169,7 +169,7 @@ This was exported from OpenStreetMap data.
             });
         }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="bing-maps-api">
@@ -181,7 +181,7 @@ This was exported from OpenStreetMap data.
       bingScriptElement.setAttribute('src', bingApiUrl);
       document.body.appendChild(bingScriptElement);
   </script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
         function initBingMap() {
             const map = new Microsoft.Maps.Map(document.getElementById('bing-maps-api-map'), {
@@ -200,14 +200,14 @@ This was exported from OpenStreetMap data.
             });
         }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="mapkit-js">
   <h2>MapKit JS (Apple Maps) API</h2>
   <div id="mapkit-js-map" style="width: 600px; height: 450px;"></div>
   <script src="https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.js"></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
         {
             mapkit.addEventListener('error', function(err) {
@@ -250,7 +250,7 @@ This was exported from OpenStreetMap data.
             });
         }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="mapbox-api">
@@ -258,7 +258,7 @@ This was exported from OpenStreetMap data.
   <div id="mapbox-api-map" style="width: 600px; height: 450px;"></div>
   <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css' rel='stylesheet' />
   <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js'></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
         { // block to restrict let and const scope to this example
             // set up map
@@ -287,7 +287,7 @@ This was exported from OpenStreetMap data.
             });
         }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="tomtom">
@@ -297,7 +297,7 @@ This was exported from OpenStreetMap data.
   <!--<link rel='stylesheet' href='https://api.tomtom.com/maps-sdk-js/4.47.6/examples/sdk/map.css'>-->
   <link rel='stylesheet' href='tomtom/maps-extract.css'>
   <link rel='stylesheet' href='https://api.tomtom.com/maps-sdk-js/4.47.6/examples/elements.css'>
-  <div class="script-example">
+  <code class="script-example">
     <script>
         {
             tomtom.setProductInfo('Maps4HTML Examples', '4.47.6');
@@ -318,14 +318,14 @@ This was exported from OpenStreetMap data.
             glooston.addTo(map);
         }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="d3-geo">
   <h2>D3 Geographies APIs</h2>
   <div id="d3-geo-map" class="d3-geo-map" style="width: 600px; height: 450px;"></div>
   <script src="https://d3js.org/d3.v5.js"></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
         {
             const handleZoom = () => {
@@ -418,7 +418,7 @@ This was exported from OpenStreetMap data.
             });
         }
     </script>
-  </div>
+  </code>
 </section>
 </body>
 </html>

--- a/examples/reset-map-view.html
+++ b/examples/reset-map-view.html
@@ -76,7 +76,7 @@ Copy & paste embed code or <p>Not applicable</p>
   <h2>Leaflet.js (with OpenStreetMap tiles)</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -85,7 +85,7 @@ or <p>Not applicable</p>
   <h2>OpenLayers with OpenStreetMap tiles</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -94,7 +94,7 @@ or <p>Not applicable</p>
   <h2>Google Maps API</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -103,7 +103,7 @@ or <p>Not applicable</p>
   <h2>Bing Maps Control API</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -112,7 +112,7 @@ or <p>Not applicable</p>
   <h2>MapKit JS (Apple Maps) API</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -121,7 +121,7 @@ or <p>Not applicable</p>
   <h2>Mapbox GL JS API</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -130,7 +130,7 @@ or <p>Not applicable</p>
   <h2>TomTom Maps SDK for Web with vector maps</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -139,7 +139,7 @@ or <p>Not applicable</p>
   <h2>D3 Geographies APIs</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>

--- a/examples/set-layer-visibility.html
+++ b/examples/set-layer-visibility.html
@@ -26,20 +26,18 @@ An example of the TileJSON representation of the map is:
 
 </p>
 <code class="script-example">
-  <pre>
-    {
-      "tilejson": "2.2.0",
-      "name": "Mississippi Stream Courses sheet 4 - Harold Fisk, US Army Corps of Engineers",
-      "attribution": "Presidential Mississippi River Commission, 1944. Public Domain.",
-      "scheme": "tms",
-      "tiles": [
-        "https://maps4html.github.io/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{-y}.png"
-      ],
-      "bounds": [-92.60431421311640, 28.79036396296392, -88.72531489137181, 31.04551669046586],
-      "minzoom": 6,
-      "maxzoom": 12
-    };
-  </pre>
+  {
+    "tilejson": "2.2.0",
+    "name": "Mississippi Stream Courses sheet 4 - Harold Fisk, US Army Corps of Engineers",
+    "attribution": "Presidential Mississippi River Commission, 1944. Public Domain.",
+    "scheme": "tms",
+    "tiles": [
+      "https://maps4html.github.io/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{-y}.png"
+    ],
+    "bounds": [-92.60431421311640, 28.79036396296392, -88.72531489137181, 31.04551669046586],
+    "minzoom": 6,
+    "maxzoom": 12
+  };
 </code>
 
 <details>

--- a/examples/set-layer-visibility.html
+++ b/examples/set-layer-visibility.html
@@ -25,20 +25,22 @@ The maps used here are the four sheets of plate 15 of the report.
 An example of the TileJSON representation of the map is:
 
 </p>
-<code class="script-example">
-  {
-    "tilejson": "2.2.0",
-    "name": "Mississippi Stream Courses sheet 4 - Harold Fisk, US Army Corps of Engineers",
-    "attribution": "Presidential Mississippi River Commission, 1944. Public Domain.",
-    "scheme": "tms",
-    "tiles": [
-      "https://maps4html.github.io/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{-y}.png"
-    ],
-    "bounds": [-92.60431421311640, 28.79036396296392, -88.72531489137181, 31.04551669046586],
-    "minzoom": 6,
-    "maxzoom": 12
-  };
-</code>
+<pre>
+  <code>
+    {
+      "tilejson": "2.2.0",
+      "name": "Mississippi Stream Courses sheet 4 - Harold Fisk, US Army Corps of Engineers",
+      "attribution": "Presidential Mississippi River Commission, 1944. Public Domain.",
+      "scheme": "tms",
+      "tiles": [
+        "https://maps4html.github.io/FiskMississippiMapsStreamCourses/sheet04/{z}/{x}/{-y}.png"
+      ],
+      "bounds": [-92.60431421311640, 28.79036396296392, -88.72531489137181, 31.04551669046586],
+      "minzoom": 6,
+      "maxzoom": 12
+    };
+  </code>
+</pre>
 
 <details>
   <summary>Jump to section…</summary>

--- a/examples/set-layer-visibility.html
+++ b/examples/set-layer-visibility.html
@@ -25,8 +25,8 @@ The maps used here are the four sheets of plate 15 of the report.
 An example of the TileJSON representation of the map is:
 
 </p>
-<pre class="script-example">
-<code>
+<code class="script-example">
+  <pre>
     {
       "tilejson": "2.2.0",
       "name": "Mississippi Stream Courses sheet 4 - Harold Fisk, US Army Corps of Engineers",
@@ -39,8 +39,8 @@ An example of the TileJSON representation of the map is:
       "minzoom": 6,
       "maxzoom": 12
     };
+  </pre>
 </code>
-</pre>
 
 <details>
   <summary>Jump to section…</summary>
@@ -105,7 +105,7 @@ An example of the TileJSON representation of the map is:
   <script src="https://unpkg.com/leaflet@1.5.1/dist/leaflet.js"
           integrity="sha512-GffPMF3RvMeYyc1LWMHtK8EbPv0iNZ8/oTtHPx9/cc2ILxQ+u905qIwdpULaqDkyBKgOaB57QTMg7ztg8Jm2Og=="
           crossorigin=""></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       {
         const map = L.map('leaflet-js-map').setView([33.024, -90.664814552244105], 6);
@@ -140,7 +140,7 @@ An example of the TileJSON representation of the map is:
         L.control.layers(baseLayers, overlayLayers, {collapsed: false}).addTo(map);
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="openlayers">
@@ -148,7 +148,7 @@ An example of the TileJSON representation of the map is:
   <div id="ol-osm-alternative-layers" style="width: 600px; height: 450px;"></div>
   <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css" type="text/css">
   <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       {
         const map = new ol.Map({
@@ -166,7 +166,7 @@ An example of the TileJSON representation of the map is:
         // TODO: finish this!
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="google-maps-api">
@@ -179,86 +179,86 @@ An example of the TileJSON representation of the map is:
       document.body.appendChild(scriptElement);
   </script>
 
-  <div class="script-example">
+  <code class="script-example">
     <script>
-        function initMap() {
-            // Create a new ImageMapType layer for each sheet.
-            const fiskLayers = m4h.fiskMaps.streamCourses.sheets.map(sheet => {
-                const TILE_URL = sheet.tileJSON.tiles[0].replace('{-y}', '{y}'),
-                    layerID = sheet.id;
-                return new google.maps.ImageMapType({
-                    name: layerID,
-                    getTileUrl: function (coord, zoom) {
-                        return TILE_URL
-                            .replace('{x}', coord.x)
-                            .replace('{y}', ((1 << zoom) - coord.y - 1)) // adjust y to account for TMS coordinates on the server
-                            .replace('{z}', zoom);
-                    },
-                    tileSize: new google.maps.Size(256, 256),
-                    minZoom: sheet.tileJSON.minzoom,
-                    maxZoom: sheet.tileJSON.maxzoom,
-                    alt: sheet.label
-                });
-            });
+      function initMap() {
+          // Create a new ImageMapType layer for each sheet.
+          const fiskLayers = m4h.fiskMaps.streamCourses.sheets.map(sheet => {
+              const TILE_URL = sheet.tileJSON.tiles[0].replace('{-y}', '{y}'),
+                  layerID = sheet.id;
+              return new google.maps.ImageMapType({
+                  name: layerID,
+                  getTileUrl: function (coord, zoom) {
+                      return TILE_URL
+                          .replace('{x}', coord.x)
+                          .replace('{y}', ((1 << zoom) - coord.y - 1)) // adjust y to account for TMS coordinates on the server
+                          .replace('{z}', zoom);
+                  },
+                  tileSize: new google.maps.Size(256, 256),
+                  minZoom: sheet.tileJSON.minzoom,
+                  maxZoom: sheet.tileJSON.maxzoom,
+                  alt: sheet.label
+              });
+          });
 
-            const mapEl = document.querySelector('#google-maps-api-map');
-            const map = new google.maps.Map(mapEl, {
-                center: new google.maps.LatLng(33.024, -90.664814552244105),
-                zoom: 6,
-                mapTypeControl: true
-            });
-            // add layers as overlay for base map
-            map.overlayMapTypes = new google.maps.MVCArray(fiskLayers);
+          const mapEl = document.querySelector('#google-maps-api-map');
+          const map = new google.maps.Map(mapEl, {
+              center: new google.maps.LatLng(33.024, -90.664814552244105),
+              zoom: 6,
+              mapTypeControl: true
+          });
+          // add layers as overlay for base map
+          map.overlayMapTypes = new google.maps.MVCArray(fiskLayers);
 
-            function GoogleOverlayMapTypeControl(map, overlayMaps) {
-                this.map = map;
-                this.overlayMaps = overlayMaps;
-                const namedOverlayMaps = this.overlayMaps.reduce((namedOverlayMaps, overlayMap) => {
-                    namedOverlayMaps[overlayMap.name] = overlayMap;
-                    return namedOverlayMaps;
-                }, {});
-                this.element = document.createElement('div');
-                this.element.classList.add('overlayMapTypeControl');
-                const fieldset = this.element.appendChild(document.createElement('fieldset')),
-                    legend = fieldset.appendChild(document.createElement('legend')),
-                    ol = fieldset.appendChild(document.createElement('ol'));
-                legend.appendChild(document.createTextNode('Layers'));
-                this.overlayMaps.forEach((overlayMap, index) => {
-                   const li = document.createElement('li'),
-                       div = li.appendChild(document.createElement('div')),
-                       checkbox = div.appendChild(document.createElement('input')),
-                       label = div.appendChild(document.createElement('label'));
-                   checkbox.type = 'checkbox';
-                   checkbox.checked = true;
-                   checkbox.name = 'layer';
-                   checkbox.id = `checkbox_${overlayMap.name}`;
-                   checkbox.dataset.overlayMapName = overlayMap.name;
-                   checkbox.dataset.index = index;
-                   label.htmlFor = checkbox.id;
-                   label.appendChild(document.createTextNode(overlayMap.alt));
-                   ol.appendChild(li);
-                });
-                this.element.addEventListener('change', function(ev) {
-                    // debugger;
-                    const checkbox = ev.target,
-                        overlayMapName = checkbox.dataset.overlayMapName,
-                        mapType = namedOverlayMaps[overlayMapName],
-                        mapIndex = checkbox.dataset.index;
-                    if (checkbox.checked) {
-                        map.overlayMapTypes.setAt(mapIndex, mapType);
-                    } else {
-                        // set value at the relevant position to null
-                        // to stop the array shifting down and breaking our indices,
-                        // which it would if we used removeAt
-                        map.overlayMapTypes.setAt(mapIndex, null);
-                    }
-                });
-            }
-            const overlayMapTypeControl = new GoogleOverlayMapTypeControl(map, fiskLayers);
-            map.controls[google.maps.ControlPosition.LEFT_TOP].push(overlayMapTypeControl.element);
-        }
+          function GoogleOverlayMapTypeControl(map, overlayMaps) {
+              this.map = map;
+              this.overlayMaps = overlayMaps;
+              const namedOverlayMaps = this.overlayMaps.reduce((namedOverlayMaps, overlayMap) => {
+                  namedOverlayMaps[overlayMap.name] = overlayMap;
+                  return namedOverlayMaps;
+              }, {});
+              this.element = document.createElement('div');
+              this.element.classList.add('overlayMapTypeControl');
+              const fieldset = this.element.appendChild(document.createElement('fieldset')),
+                  legend = fieldset.appendChild(document.createElement('legend')),
+                  ol = fieldset.appendChild(document.createElement('ol'));
+              legend.appendChild(document.createTextNode('Layers'));
+              this.overlayMaps.forEach((overlayMap, index) => {
+                 const li = document.createElement('li'),
+                     div = li.appendChild(document.createElement('div')),
+                     checkbox = div.appendChild(document.createElement('input')),
+                     label = div.appendChild(document.createElement('label'));
+                 checkbox.type = 'checkbox';
+                 checkbox.checked = true;
+                 checkbox.name = 'layer';
+                 checkbox.id = `checkbox_${overlayMap.name}`;
+                 checkbox.dataset.overlayMapName = overlayMap.name;
+                 checkbox.dataset.index = index;
+                 label.htmlFor = checkbox.id;
+                 label.appendChild(document.createTextNode(overlayMap.alt));
+                 ol.appendChild(li);
+              });
+              this.element.addEventListener('change', function(ev) {
+                  // debugger;
+                  const checkbox = ev.target,
+                      overlayMapName = checkbox.dataset.overlayMapName,
+                      mapType = namedOverlayMaps[overlayMapName],
+                      mapIndex = checkbox.dataset.index;
+                  if (checkbox.checked) {
+                      map.overlayMapTypes.setAt(mapIndex, mapType);
+                  } else {
+                      // set value at the relevant position to null
+                      // to stop the array shifting down and breaking our indices,
+                      // which it would if we used removeAt
+                      map.overlayMapTypes.setAt(mapIndex, null);
+                  }
+              });
+          }
+          const overlayMapTypeControl = new GoogleOverlayMapTypeControl(map, fiskLayers);
+          map.controls[google.maps.ControlPosition.LEFT_TOP].push(overlayMapTypeControl.element);
+      }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="bing-maps-api">
@@ -270,107 +270,107 @@ An example of the TileJSON representation of the map is:
       bingScriptElement.setAttribute('src', bingApiUrl);
       document.body.appendChild(bingScriptElement);
   </script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
-        function initBingMap() {
-            // Create a new TileLayer with a TileSource for each sheet.
-            const fiskLayers = m4h.fiskMaps.streamCourses.sheets.map(sheet => {
-                const TILE_URL = sheet.tileJSON.tiles[0].replace('{-y}', '{y}');
-                const tileSource = new Microsoft.Maps.TileSource({
-                    uriConstructor: function (coord, zoom) {
-                        return TILE_URL
-                            .replace('{x}', coord.x)
-                            .replace('{y}', ((1 << coord.zoom) - coord.y - 1)) // adjust y to account for TMS coordinates on the server
-                            .replace('{z}', coord.zoom);
-                    },
-                    // tileSize: new google.maps.Size(256, 256),
-                    minZoom: sheet.tileJSON.minzoom,
-                    maxZoom: sheet.tileJSON.maxzoom,
-                    bounds: Microsoft.Maps.LocationRect.fromEdges(
-                        sheet.tileJSON.bounds[3],
-                        sheet.tileJSON.bounds[0],
-                        sheet.tileJSON.bounds[1],
-                        sheet.tileJSON.bounds[2]
-                    )
-                });
-                const layer = new Microsoft.Maps.TileLayer({
-                    mercator: tileSource
-                });
-                layer.metadata = {
-                    'id': sheet.id,
-                    'label': sheet.label
-                };
-                return layer;
-            });
+      function initBingMap() {
+          // Create a new TileLayer with a TileSource for each sheet.
+          const fiskLayers = m4h.fiskMaps.streamCourses.sheets.map(sheet => {
+              const TILE_URL = sheet.tileJSON.tiles[0].replace('{-y}', '{y}');
+              const tileSource = new Microsoft.Maps.TileSource({
+                  uriConstructor: function (coord, zoom) {
+                      return TILE_URL
+                          .replace('{x}', coord.x)
+                          .replace('{y}', ((1 << coord.zoom) - coord.y - 1)) // adjust y to account for TMS coordinates on the server
+                          .replace('{z}', coord.zoom);
+                  },
+                  // tileSize: new google.maps.Size(256, 256),
+                  minZoom: sheet.tileJSON.minzoom,
+                  maxZoom: sheet.tileJSON.maxzoom,
+                  bounds: Microsoft.Maps.LocationRect.fromEdges(
+                      sheet.tileJSON.bounds[3],
+                      sheet.tileJSON.bounds[0],
+                      sheet.tileJSON.bounds[1],
+                      sheet.tileJSON.bounds[2]
+                  )
+              });
+              const layer = new Microsoft.Maps.TileLayer({
+                  mercator: tileSource
+              });
+              layer.metadata = {
+                  'id': sheet.id,
+                  'label': sheet.label
+              };
+              return layer;
+          });
 
-            const map = new Microsoft.Maps.Map(document.getElementById('bing-maps-api-map'), {
-                center: new Microsoft.Maps.Location(33.024, -90.664814552244105),
-                zoom: 6,
-                showMapTypeSelector: true,
-                showLocateMeButton: false
-            });
-            map.layers.insertAll(fiskLayers);
+          const map = new Microsoft.Maps.Map(document.getElementById('bing-maps-api-map'), {
+              center: new Microsoft.Maps.Location(33.024, -90.664814552244105),
+              zoom: 6,
+              showMapTypeSelector: true,
+              showLocateMeButton: false
+          });
+          map.layers.insertAll(fiskLayers);
 
-            function BingOverlayMapLayerControl(map, overlayMaps) {
-                this.map = map;
-                this.overlayMaps = overlayMaps;
-                const mapTypesByName = this.overlayMaps.reduce((mapTypesByName, overlayMap) => {
-                    mapTypesByName[overlayMap.metadata.id] = overlayMap;
-                    return mapTypesByName;
-                }, {});
-                this.element = document.createElement('div');
-                this.element.classList.add('overlayMapTypeControl');
-                const fieldset = this.element.appendChild(document.createElement('fieldset')),
-                    legend = fieldset.appendChild(document.createElement('legend')),
-                    ol = fieldset.appendChild(document.createElement('ol'));
-                legend.appendChild(document.createTextNode('Layers'));
-                this.overlayMaps.forEach((overlayMap, index) => {
-                    const li = document.createElement('li'),
-                        div = li.appendChild(document.createElement('div')),
-                        checkbox = div.appendChild(document.createElement('input')),
-                        label = div.appendChild(document.createElement('label'));
-                    checkbox.type = 'checkbox';
-                    checkbox.checked = true;
-                    checkbox.name = 'layer';
-                    checkbox.id = `checkbox_${overlayMap.metadata.id}`;
-                    checkbox.dataset.overlayMapName = overlayMap.metadata.id;
-                    checkbox.dataset.index = index;
-                    label.htmlFor = checkbox.id;
-                    label.appendChild(document.createTextNode(overlayMap.metadata.label));
-                    ol.appendChild(li);
-                });
-                this.element.addEventListener('change', function(ev) {
-                    // debugger;
-                    const checkbox = ev.target,
-                        overlayMapName = checkbox.dataset.overlayMapName,
-                        overlayMap = mapTypesByName[overlayMapName],
-                        mapIndex = checkbox.dataset.index;
-                    overlayMap.setVisible(checkbox.checked);
-                });
-            }
-            BingOverlayMapLayerControl.prototype = new Microsoft.Maps.CustomOverlay({
-                beneathLabels: false
-            });
-            BingOverlayMapLayerControl.prototype.onAdd = function() {
-                this.setHtmlElement(this.element);
-            };
-            BingOverlayMapLayerControl.prototype.onLoad = function() {
-            };
-            BingOverlayMapLayerControl.prototype.onRemove = function() {
-            };
-            const overlayMapTypeControl = new BingOverlayMapLayerControl(map, fiskLayers);
-            map.layers.insert(overlayMapTypeControl);
+          function BingOverlayMapLayerControl(map, overlayMaps) {
+              this.map = map;
+              this.overlayMaps = overlayMaps;
+              const mapTypesByName = this.overlayMaps.reduce((mapTypesByName, overlayMap) => {
+                  mapTypesByName[overlayMap.metadata.id] = overlayMap;
+                  return mapTypesByName;
+              }, {});
+              this.element = document.createElement('div');
+              this.element.classList.add('overlayMapTypeControl');
+              const fieldset = this.element.appendChild(document.createElement('fieldset')),
+                  legend = fieldset.appendChild(document.createElement('legend')),
+                  ol = fieldset.appendChild(document.createElement('ol'));
+              legend.appendChild(document.createTextNode('Layers'));
+              this.overlayMaps.forEach((overlayMap, index) => {
+                  const li = document.createElement('li'),
+                      div = li.appendChild(document.createElement('div')),
+                      checkbox = div.appendChild(document.createElement('input')),
+                      label = div.appendChild(document.createElement('label'));
+                  checkbox.type = 'checkbox';
+                  checkbox.checked = true;
+                  checkbox.name = 'layer';
+                  checkbox.id = `checkbox_${overlayMap.metadata.id}`;
+                  checkbox.dataset.overlayMapName = overlayMap.metadata.id;
+                  checkbox.dataset.index = index;
+                  label.htmlFor = checkbox.id;
+                  label.appendChild(document.createTextNode(overlayMap.metadata.label));
+                  ol.appendChild(li);
+              });
+              this.element.addEventListener('change', function(ev) {
+                  // debugger;
+                  const checkbox = ev.target,
+                      overlayMapName = checkbox.dataset.overlayMapName,
+                      overlayMap = mapTypesByName[overlayMapName],
+                      mapIndex = checkbox.dataset.index;
+                  overlayMap.setVisible(checkbox.checked);
+              });
+          }
+          BingOverlayMapLayerControl.prototype = new Microsoft.Maps.CustomOverlay({
+              beneathLabels: false
+          });
+          BingOverlayMapLayerControl.prototype.onAdd = function() {
+              this.setHtmlElement(this.element);
+          };
+          BingOverlayMapLayerControl.prototype.onLoad = function() {
+          };
+          BingOverlayMapLayerControl.prototype.onRemove = function() {
+          };
+          const overlayMapTypeControl = new BingOverlayMapLayerControl(map, fiskLayers);
+          map.layers.insert(overlayMapTypeControl);
 
-        }
+      }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="mapkit-js">
   <h2>MapKit JS (Apple Maps) API</h2>
 
   ***TODO<!--
-  Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+  Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
   -->***
 </section>
 
@@ -379,7 +379,7 @@ An example of the TileJSON representation of the map is:
   <div id="mapboxgl-alternative-layers" style="width: 600px; height: 450px;"></div>
   <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css' rel='stylesheet' />
   <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js'></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       mapboxgl.accessToken = m4h.keys.mapboxGL;
       let map = new mapboxgl.Map({
@@ -390,14 +390,14 @@ An example of the TileJSON representation of the map is:
       });
       // TODO: finish this!
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="tomtom">
   <h2>TomTom Maps SDK for Web with vector maps</h2>
 
   ***TODO<!--
-  Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+  Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
   -->***
 </section>
 
@@ -405,7 +405,7 @@ An example of the TileJSON representation of the map is:
   <h2>D3 Geographies APIs</h2>
 
   ***TODO<!--
-  Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+  Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
   -->***
 </section>
 </body>

--- a/examples/set-view-zoom.html
+++ b/examples/set-view-zoom.html
@@ -85,7 +85,7 @@
   <script src="https://unpkg.com/leaflet@1.5.1/dist/leaflet.js"
           integrity="sha512-GffPMF3RvMeYyc1LWMHtK8EbPv0iNZ8/oTtHPx9/cc2ILxQ+u905qIwdpULaqDkyBKgOaB57QTMg7ztg8Jm2Og=="
           crossorigin=""></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       {
         let map = L.map('leaflet-js-map').setView([46.233226, 6.055737], 15);
@@ -113,7 +113,7 @@
         });
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="openlayers">
@@ -137,7 +137,7 @@
   </div>
   <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css" type="text/css">
   <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       {
         const view = new ol.View({
@@ -178,7 +178,7 @@
         });
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="google-maps-api">
@@ -206,7 +206,7 @@
     scriptElement.setAttribute('src', apiUrl);
     document.body.appendChild(scriptElement);
   </script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       function initMap() {
         // set up the map
@@ -243,7 +243,7 @@
         });
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="bing-maps-api">
@@ -271,7 +271,7 @@
     bingScriptElement.setAttribute('src', bingApiUrl);
     document.body.appendChild(bingScriptElement);
   </script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       function initBingMap() {
         // set up the map
@@ -313,7 +313,7 @@
         });
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="mapkit-js">
@@ -336,7 +336,7 @@
     <div id="mapkit-js-map"></div>
   </div>
   <script src="https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.js"></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       {
         mapkit.addEventListener('error', function(err) {
@@ -385,7 +385,7 @@
         });
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="mapbox-api">
@@ -409,7 +409,7 @@
   </div>
   <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css' rel='stylesheet' />
   <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js'></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       {
         mapboxgl.accessToken = m4h.keys.mapboxGL;
@@ -441,7 +441,7 @@
         });
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="tomtom">
@@ -467,7 +467,7 @@
   <!--<link rel='stylesheet' href='https://api.tomtom.com/maps-sdk-js/4.47.6/examples/sdk/map.css'>-->
   <link rel='stylesheet' href='tomtom/maps-extract.css'>
   <link rel='stylesheet' href='https://api.tomtom.com/maps-sdk-js/4.47.6/examples/elements.css'>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       {
         tomtom.setProductInfo('Maps4HTML Examples', '4.47.6');
@@ -498,14 +498,14 @@
         });
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="d3-geo">
   <h2>D3 Geographies APIs</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>

--- a/examples/single-location.html
+++ b/examples/single-location.html
@@ -120,7 +120,7 @@ for how to add point markers with the other services (where possible).
   <script src="https://unpkg.com/leaflet@1.5.1/dist/leaflet.js"
     integrity="sha512-GffPMF3RvMeYyc1LWMHtK8EbPv0iNZ8/oTtHPx9/cc2ILxQ+u905qIwdpULaqDkyBKgOaB57QTMg7ztg8Jm2Og=="
     crossorigin=""></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
         {
             const map = L.map('leaflet-js-map').setView([46.233226, 6.055737], 15);
@@ -133,7 +133,7 @@ for how to add point markers with the other services (where possible).
             centerMarker.addTo(map);
         }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="openlayers">
@@ -141,7 +141,7 @@ for how to add point markers with the other services (where possible).
   <div id="openlayers-map" style="width: 600px; height: 450px;"></div>
   <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css" type="text/css">
   <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
         {
             const vectorLayerFeatures = [];
@@ -180,7 +180,7 @@ for how to add point markers with the other services (where possible).
             vectorLayer.getSource().addFeature(centerMarker);
         }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="google-maps-api">
@@ -192,7 +192,7 @@ for how to add point markers with the other services (where possible).
       scriptElement.setAttribute('src', apiUrl);
       document.body.appendChild(scriptElement);
   </script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       function initMap() {
           // set up the map
@@ -211,7 +211,7 @@ for how to add point markers with the other services (where possible).
           });
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="bing-maps-api">
@@ -223,7 +223,7 @@ for how to add point markers with the other services (where possible).
       bingScriptElement.setAttribute('src', bingApiUrl);
       document.body.appendChild(bingScriptElement);
   </script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
         function initBingMap() {
             // set up the map
@@ -237,14 +237,14 @@ for how to add point markers with the other services (where possible).
             map.entities.push(centerMarker);
         }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="mapkit-js">
   <h2>MapKit JS (Apple Maps) API</h2>
   <div id="mapkit-js-map" style="width: 600px; height: 450px;"></div>
   <script src="https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.js"></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       {
         mapkit.addEventListener('error', function(err) {
@@ -275,7 +275,7 @@ for how to add point markers with the other services (where possible).
         map.addAnnotation(marker);
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="mapbox-api">
@@ -283,7 +283,7 @@ for how to add point markers with the other services (where possible).
   <div id="mapbox-api-map" style="width: 600px; height: 450px;"></div>
   <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css' rel='stylesheet' />
   <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js'></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       { // block to restrict let and const scope to this example
           // set up map
@@ -301,7 +301,7 @@ for how to add point markers with the other services (where possible).
           centerMarker.addTo(map);
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="tomtom">
@@ -309,7 +309,7 @@ for how to add point markers with the other services (where possible).
   <div id="tomtom-single-location" style="width: 600px; height: 450px;"></div>
   <script src='https://api.tomtom.com/maps-sdk-js/4.47.6/examples/sdk/tomtom.min.js'></script>
   <link rel='stylesheet' href='https://api.tomtom.com/maps-sdk-js/4.47.6/examples/elements.css'>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       {
         tomtom.setProductInfo('Maps4HTML Examples', '4.47.6');
@@ -324,14 +324,14 @@ for how to add point markers with the other services (where possible).
         centerMarker.addTo(map);
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="d3-geo">
   <h2>D3 Geographies APIs</h2>
   <div id="d3-geo-map" class="d3-geo-map" style="width: 600px; height: 450px;"></div>
   <script src="https://d3js.org/d3.v5.js"></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
         {
             const handleZoom = () => {
@@ -403,7 +403,7 @@ for how to add point markers with the other services (where possible).
             });
         }
     </script>
-  </div>
+  </code>
 </section>
 </body>
 </html>

--- a/examples/specify-data-source-map.html
+++ b/examples/specify-data-source-map.html
@@ -76,7 +76,7 @@ Copy & paste embed code or <p>Not applicable</p>
   <h2>Leaflet.js (with OpenStreetMap tiles)</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -85,7 +85,7 @@ or <p>Not applicable</p>
   <h2>OpenLayers with OpenStreetMap tiles</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -94,7 +94,7 @@ or <p>Not applicable</p>
   <h2>Google Maps API</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -103,7 +103,7 @@ or <p>Not applicable</p>
   <h2>Bing Maps Control API</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -112,7 +112,7 @@ or <p>Not applicable</p>
   <h2>MapKit JS (Apple Maps) API</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -121,7 +121,7 @@ or <p>Not applicable</p>
   <h2>Mapbox GL JS API</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -130,7 +130,7 @@ or <p>Not applicable</p>
   <h2>TomTom Maps SDK for Web with vector maps</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -139,7 +139,7 @@ or <p>Not applicable</p>
   <h2>D3 Geographies APIs</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>

--- a/examples/static-map.html
+++ b/examples/static-map.html
@@ -47,7 +47,7 @@ Static map APIs allow a non-interactive map to be embedded in a webpage as an im
           const location = '51.4082343,30.0558434';
           const staticMapURL = `https://maps.googleapis.com/maps/api/staticmap?center=${location}&zoom=16&size=640x480&markers=color:red|location:51.408365,30.055867&key=${m4h.keys.google}`;
           const mapEmbedElement = document.querySelector('#google-maps .static-embed');
-          const mapCodeElement = document.querySelectorAll('#google-maps code span');
+          const mapCodeElement = document.querySelectorAll('#google-maps .html-example span');
           const staticMap = document.createElement('img');
           staticMap.src = staticMapURL;
           staticMap.alt = 'Pripyat Amusement Park';
@@ -68,7 +68,8 @@ Static map APIs allow a non-interactive map to be embedded in a webpage as an im
 
 <section id="bing-maps">
   <h2>Bing Static Map image</h2>
-  <code class="html-example"></code>
+  <code class="html-example">
+  </code>
   <div class="static-embed">
   </div>
   <script>
@@ -76,7 +77,7 @@ Static map APIs allow a non-interactive map to be embedded in a webpage as an im
           const location = '51.4082343,30.0558434';
           const staticMapURL = `https://dev.virtualearth.net/REST/v1/Imagery/Map/Road/${location}/16?mapSize=640,480&pushpin=51.408365,30.055867;0;&format=png&key=${m4h.keys.bing}`;
           const mapEmbedElement = document.querySelector('#bing-maps .static-embed');
-          const mapCodeElement = document.querySelectorAll('#bing-maps code');
+          const mapCodeElement = document.querySelectorAll('#bing-maps .html-example');
           const staticMap = document.createElement('img');
           staticMap.src = staticMapURL;
           staticMap.alt = 'Pripyat Amusement Park';
@@ -98,7 +99,7 @@ Static map APIs allow a non-interactive map to be embedded in a webpage as an im
           const location = ['51.4082343','30.0558434'];
           const staticMapURL = `https://api.mapbox.com/styles/v1/mapbox/light-v9/static/pin-s+f00(30.055867,51.408365)/${location[1]},${location[0]},15,0,0/640x480?access_token=pk.eyJ1Ijoibmlja2ZpdHoiLCJhIjoiY2p3d2g3N2F5MDZ4azQwcG12dWticDB0diJ9.qnQV5QgYN_eDwg4uUdbO6Q`;
           const mapEmbedElement = document.querySelector('#mapbox .static-embed');
-          const mapCodeElement = document.querySelectorAll('#mapbox code');
+          const mapCodeElement = document.querySelectorAll('#mapbox .html-example');
           const staticMap = document.createElement('img');
           staticMap.src = staticMapURL;
           staticMap.alt = 'Pripyat Amusement Park';
@@ -125,7 +126,7 @@ Static map APIs allow a non-interactive map to be embedded in a webpage as an im
           const { referer, teamId, keyId, signature} = mapkitAuth;
           const staticMapURL = `https://snapshot.apple-mapkit.com/api/v1/snapshot?center=${location}&z=16&size=640x480&referer=${referer}&teamId=${teamId}&keyId=${keyId}&signature=${signature}`;
           const mapEmbedElement = document.querySelector('#mapkit .static-embed');
-          const mapCodeElement = document.querySelectorAll('#mapkit code');
+          const mapCodeElement = document.querySelectorAll('#mapkit .html-example');
           const staticMap = document.createElement('img');
           staticMap.src = staticMapURL;
           staticMap.alt = 'Pripyat Amusement Park';
@@ -147,7 +148,7 @@ Static map APIs allow a non-interactive map to be embedded in a webpage as an im
           const location = '30.0558434,51.4082343';
           const staticMapURL = `https://api.tomtom.com/map/1/staticimage?center=${location}&zoom=15&width=640&height=480&layer=basic&style=main&format=png&view=Unified&key=${m4h.keys.tomtom}`;
           const mapEmbedElement = document.querySelector('#tomtom .static-embed');
-          const mapCodeElement = document.querySelectorAll('#tomtom code');
+          const mapCodeElement = document.querySelectorAll('#tomtom .html-example');
           const staticMap = document.createElement('img');
           staticMap.src = staticMapURL;
           staticMap.alt = 'Pripyat Amusement Park';

--- a/examples/static-map.html
+++ b/examples/static-map.html
@@ -33,18 +33,12 @@ Static map APIs allow a non-interactive map to be embedded in a webpage as an im
 
 <section id="google-maps">
   <h2>Google Static Maps &amp; Static Street View images</h2>
-  <div class="html-example">
-    <br>
-    Map:
-    <br>
-    <code>
-    </code>
-    Streetview:
-    <br>
-    <code>
-    </code>
-    <br>
-  </div>
+  <code class="html-example">
+&lt;!-- Map --&gt;
+<div></div>
+&lt;!-- Street view --&gt;
+<div></div>
+  </code>
   <div class="static-embed with-streetview">
   </div>
   <script>
@@ -52,7 +46,7 @@ Static map APIs allow a non-interactive map to be embedded in a webpage as an im
           const location = '51.4082343,30.0558434';
           const staticMapURL = `https://maps.googleapis.com/maps/api/staticmap?center=${location}&zoom=16&size=640x480&markers=color:red|location:51.408365,30.055867&key=${m4h.keys.google}`;
           const mapEmbedElement = document.querySelector('#google-maps .static-embed');
-          const mapCodeElement = document.querySelectorAll('#google-maps .html-example code');
+          const mapCodeElement = document.querySelectorAll('#google-maps code div');
           const staticMap = document.createElement('img');
           staticMap.src = staticMapURL;
           staticMap.alt = 'Pripyat Amusement Park';
@@ -73,14 +67,8 @@ Static map APIs allow a non-interactive map to be embedded in a webpage as an im
 
 <section id="bing-maps">
   <h2>Bing Static Map image</h2>
-  <div class="html-example">
-    <br>
-    Map:
-    <br>
-    <code>
-    </code>
-    <br>
-  </div>
+  <code class="html-example">
+  </code>
   <div class="static-embed">
   </div>
   <script>
@@ -88,7 +76,7 @@ Static map APIs allow a non-interactive map to be embedded in a webpage as an im
           const location = '51.4082343,30.0558434';
           const staticMapURL = `https://dev.virtualearth.net/REST/v1/Imagery/Map/Road/${location}/16?mapSize=640,480&pushpin=51.408365,30.055867;0;&format=png&key=${m4h.keys.bing}`;
           const mapEmbedElement = document.querySelector('#bing-maps .static-embed');
-          const mapCodeElement = document.querySelectorAll('#bing-maps .html-example code');
+          const mapCodeElement = document.querySelectorAll('#bing-maps code');
           const staticMap = document.createElement('img');
           staticMap.src = staticMapURL;
           staticMap.alt = 'Pripyat Amusement Park';
@@ -101,14 +89,8 @@ Static map APIs allow a non-interactive map to be embedded in a webpage as an im
 
 <section id="mapbox">
   <h2>MapBox Static Map image</h2>
-  <div class="html-example">
-    <br>
-    Map:
-    <br>
-    <code>
-    </code>
-    <br>
-  </div>
+  <code class="html-example">
+  </code>
   <div class="static-embed">
   </div>
   <script>
@@ -116,7 +98,7 @@ Static map APIs allow a non-interactive map to be embedded in a webpage as an im
           const location = ['51.4082343','30.0558434'];
           const staticMapURL = `https://api.mapbox.com/styles/v1/mapbox/light-v9/static/pin-s+f00(30.055867,51.408365)/${location[1]},${location[0]},15,0,0/640x480?access_token=pk.eyJ1Ijoibmlja2ZpdHoiLCJhIjoiY2p3d2g3N2F5MDZ4azQwcG12dWticDB0diJ9.qnQV5QgYN_eDwg4uUdbO6Q`;
           const mapEmbedElement = document.querySelector('#mapbox .static-embed');
-          const mapCodeElement = document.querySelectorAll('#mapbox .html-example code');
+          const mapCodeElement = document.querySelectorAll('#mapbox code');
           const staticMap = document.createElement('img');
           staticMap.src = staticMapURL;
           staticMap.alt = 'Pripyat Amusement Park';
@@ -129,14 +111,8 @@ Static map APIs allow a non-interactive map to be embedded in a webpage as an im
 
 <section id="mapkit">
   <h2>MapKit Snapshot image</h2>
-  <div class="html-example">
-    <br>
-    Map:
-    <br>
-    <code>
-    </code>
-    <br>
-  </div>
+  <code class="html-example">
+  </code>
   <div class="static-embed">
   </div>
   <script>
@@ -149,7 +125,7 @@ Static map APIs allow a non-interactive map to be embedded in a webpage as an im
           const { referer, teamId, keyId, signature} = mapkitAuth;
           const staticMapURL = `https://snapshot.apple-mapkit.com/api/v1/snapshot?center=${location}&z=16&size=640x480&referer=${referer}&teamId=${teamId}&keyId=${keyId}&signature=${signature}`;
           const mapEmbedElement = document.querySelector('#mapkit .static-embed');
-          const mapCodeElement = document.querySelectorAll('#mapkit .html-example code');
+          const mapCodeElement = document.querySelectorAll('#mapkit code');
           const staticMap = document.createElement('img');
           staticMap.src = staticMapURL;
           staticMap.alt = 'Pripyat Amusement Park';
@@ -162,14 +138,8 @@ Static map APIs allow a non-interactive map to be embedded in a webpage as an im
 
 <section id="tomtom">
   <h2>TomTom Static Map image</h2>
-  <div class="html-example">
-    <br>
-    Map:
-    <br>
-    <code>
-    </code>
-    <br>
-  </div>
+  <code class="html-example">
+  </code>
   <div class="static-embed">
   </div>
   <script>
@@ -177,7 +147,7 @@ Static map APIs allow a non-interactive map to be embedded in a webpage as an im
           const location = '30.0558434,51.4082343';
           const staticMapURL = `https://api.tomtom.com/map/1/staticimage?center=${location}&zoom=15&width=640&height=480&layer=basic&style=main&format=png&view=Unified&key=${m4h.keys.tomtom}`;
           const mapEmbedElement = document.querySelector('#tomtom .static-embed');
-          const mapCodeElement = document.querySelectorAll('#tomtom .html-example code');
+          const mapCodeElement = document.querySelectorAll('#tomtom code');
           const staticMap = document.createElement('img');
           staticMap.src = staticMapURL;
           staticMap.alt = 'Pripyat Amusement Park';

--- a/examples/static-map.html
+++ b/examples/static-map.html
@@ -33,12 +33,13 @@ Static map APIs allow a non-interactive map to be embedded in a webpage as an im
 
 <section id="google-maps">
   <h2>Google Static Maps &amp; Static Street View images</h2>
-  <code class="html-example">
+<code class="html-example">
 &lt;!-- Map --&gt;
-<div></div>
+<span></span>
+
 &lt;!-- Street view --&gt;
-<div></div>
-  </code>
+<span></span>
+</code>
   <div class="static-embed with-streetview">
   </div>
   <script>
@@ -46,7 +47,7 @@ Static map APIs allow a non-interactive map to be embedded in a webpage as an im
           const location = '51.4082343,30.0558434';
           const staticMapURL = `https://maps.googleapis.com/maps/api/staticmap?center=${location}&zoom=16&size=640x480&markers=color:red|location:51.408365,30.055867&key=${m4h.keys.google}`;
           const mapEmbedElement = document.querySelector('#google-maps .static-embed');
-          const mapCodeElement = document.querySelectorAll('#google-maps code div');
+          const mapCodeElement = document.querySelectorAll('#google-maps code span');
           const staticMap = document.createElement('img');
           staticMap.src = staticMapURL;
           staticMap.alt = 'Pripyat Amusement Park';
@@ -67,8 +68,7 @@ Static map APIs allow a non-interactive map to be embedded in a webpage as an im
 
 <section id="bing-maps">
   <h2>Bing Static Map image</h2>
-  <code class="html-example">
-  </code>
+  <code class="html-example"></code>
   <div class="static-embed">
   </div>
   <script>

--- a/examples/technical-drawings.html
+++ b/examples/technical-drawings.html
@@ -81,7 +81,7 @@
   <script src="https://unpkg.com/leaflet@1.5.1/dist/leaflet.js"
           integrity="sha512-GffPMF3RvMeYyc1LWMHtK8EbPv0iNZ8/oTtHPx9/cc2ILxQ+u905qIwdpULaqDkyBKgOaB57QTMg7ztg8Jm2Og=="
           crossorigin=""></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
     {
       const map = L.map('leaflet-js-map').setView([0,0], 1);
@@ -92,7 +92,7 @@
       }).addTo(map);
     }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="openlayers">
@@ -100,7 +100,7 @@
   <div id="openlayers-map" style="width: 600px; height: 450px;"></div>
   <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css" type="text/css">
   <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
     const map = (() => {
       const pictureLayer = new ol.layer.Tile({
@@ -130,14 +130,14 @@
       return map;
     })();
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="google-maps-api">
   <h2>Google Maps API</h2>
 
   ***TODO<!--
-  Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+  Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
   or <p>Not applicable</p>
   -->***
 </section>
@@ -146,7 +146,7 @@
   <h2>Bing Maps Control API</h2>
 
   ***TODO<!--
-  Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+  Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
   or <p>Not applicable</p>
   -->***
 </section>
@@ -155,7 +155,7 @@
   <h2>MapKit JS (Apple Maps) API</h2>
 
   ***TODO<!--
-  Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+  Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
   or <p>Not applicable</p>
   -->***
 </section>
@@ -165,7 +165,7 @@
   <div id="mapbox-api-map" style="width: 600px; height: 450px;"></div>
   <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css' rel='stylesheet' />
   <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js'></script>
-  <div class="script-example">
+  <code class="script-example">
     <script>
       { // block to restrict let and const scope to this example
         // set up map
@@ -198,14 +198,14 @@
         map.addControl(new mapboxgl.NavigationControl());
       }
     </script>
-  </div>
+  </code>
 </section>
 
 <section id="tomtom">
   <h2>TomTom Maps SDK for Web with vector maps</h2>
 
   ***TODO<!--
-  Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+  Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
   or <p>Not applicable</p>
   -->***
 </section>
@@ -214,7 +214,7 @@
   <h2>D3 Geographies APIs</h2>
 
   ***TODO<!--
-  Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+  Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
   or <p>Not applicable</p>
   -->***
 </section>

--- a/examples/view-change-events.html
+++ b/examples/view-change-events.html
@@ -76,7 +76,7 @@ Copy & paste embed code or <p>Not applicable</p>
   <h2>Leaflet.js (with OpenStreetMap tiles)</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -85,7 +85,7 @@ or <p>Not applicable</p>
   <h2>OpenLayers with OpenStreetMap tiles</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -94,7 +94,7 @@ or <p>Not applicable</p>
   <h2>Google Maps API</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -103,7 +103,7 @@ or <p>Not applicable</p>
   <h2>Bing Maps Control API</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -112,7 +112,7 @@ or <p>Not applicable</p>
   <h2>MapKit JS (Apple Maps) API</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -121,7 +121,7 @@ or <p>Not applicable</p>
   <h2>Mapbox GL JS API</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -130,7 +130,7 @@ or <p>Not applicable</p>
   <h2>TomTom Maps SDK for Web with vector maps</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>
@@ -139,7 +139,7 @@ or <p>Not applicable</p>
   <h2>D3 Geographies APIs</h2>
 
   ***TODO<!--
-Replace with code including link/external scripts. Custom script has <div class="script-example"> parent element.
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
 or <p>Not applicable</p>
 -->***
 </section>


### PR DESCRIPTION
- [x] Use the more appropriate `<code>` element as opposed to `<div>` for blocks of code.
- [x] Update styles for the code blocks, see screenshots below for quick comparison.

<hr>

### Current look:

<img width="550" src="https://user-images.githubusercontent.com/26493779/80712788-c3ce0900-8af2-11ea-9c4a-9da020d20383.png">

### New look:

<img width="550" src="https://user-images.githubusercontent.com/26493779/81440367-3af94200-9170-11ea-8ec2-d789f03aedd6.png">

WDYT?