### PR TITLE
Fix broken capability reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -2059,7 +2059,7 @@ Discuss this section on GitHub.
 
 <h5>Required capabilities</h5>
 <ul data-ucr-role="required-capabilities">
-<li><a href="#capability-zoom-map-in-or-out"></a></li>
+<li><a href="#capability-pan-zoom-or-re-centre-map"></a></li>
 <li><a href="#capability-move-the-map-to-display-a-given-location"></a></li>
 <li><a href="#capability-pan-and-zoom-to-bounding-box"></a></li>
 </ul>


### PR DESCRIPTION
`id="capability-zoom-map-in-or-out"` was removed in https://github.com/Maps4HTML/HTML-Map-Element-UseCases-Requirements/pull/217, updating the remaining reference.