### PR TITLE
Update ReSpec profile

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,7 +163,7 @@ respecConfig.otherLinks = [
   }
 ]
 </script>
-<script src='https://www.w3.org/Tools/respec/respec-w3c-common'
+<script src='https://www.w3.org/Tools/respec/respec-w3c'
         defer class='remove'></script>
 </head>
 <body>


### PR DESCRIPTION
https://github.com/w3c/respec/wiki/respec-w3c-common-migration-guide:

> The `respec-w3c-common` ReSpec profile has been deprecated and will not receive any updates in future, including the support for [W3C 2020 Process](https://www.w3.org/2020/Process-20200915/).

> The `respec-w3c` profile contains security, performance, and new features plus support for the W3C's 2020 Process and future W3C Process/template updates. As such, it's highly recommended that you do upgrade.