### PR TITLE
Add missing page titles, headings, and link to corresponding section in the report

### DIFF
--- a/examples/alternative-layers.html
+++ b/examples/alternative-layers.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Provide alternative map layers which the user can select</title>
+  <title>Provide alternative map layers which the user can select — Maps for HTML reference examples</title>
   <link rel="stylesheet" href="examples.css">
   <script src="api-keys.js"></script>
 </head>

--- a/examples/change-bearing-map.html
+++ b/examples/change-bearing-map.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Change the Bearing of a Map</title>
+  <title>Change the Bearing of a Map — Maps for HTML reference examples</title>
   <link rel="stylesheet" href="examples.css">
   <script src="api-keys.js"></script>
 </head>

--- a/examples/create-map.html
+++ b/examples/create-map.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Display an interactive map</title>
+  <title>Display an interactive map — Maps for HTML reference examples</title>
   <link rel="stylesheet" href="examples.css">
   <script src="api-keys.js"></script>
 </head>

--- a/examples/generate-vector-features.html
+++ b/examples/generate-vector-features.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>***Description*** — Maps for HTML reference examples</title>
+  <title>Show a vector data overlay — Maps for HTML reference examples</title>
   <link rel="stylesheet" href="examples.css">
   <script src="api-keys.js"></script>
 </head>
 <body>
 <h1>Examples for
-  <a href="../#use-case-***ID***">Use Case: ***Title***</a>
+  <a href="../#use-case-generate-vector-features">Use Case: Generate new vector features from data</a>
 </h1>
 
 <p>

--- a/examples/heatmap.html
+++ b/examples/heatmap.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>***Description*** — Maps for HTML reference examples</title>
+  <title>Generate a heatmap overlay — Maps for HTML reference examples</title>
   <link rel="stylesheet" href="examples.css">
   <script src="api-keys.js"></script>
 </head>
 <body>
 <h1>Examples for
-  <a href="../#use-case-***ID***">Use Case: ***Title***</a>
+  <a href="../#use-case-heatmap">Use Case: Generate a heatmap overlay from point intensity data</a>
 </h1>
 
 <p>

--- a/examples/reset-map-view.html
+++ b/examples/reset-map-view.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>***Description*** — Maps for HTML reference examples</title>
+  <title>Allow users to reset the map to their starting point — Maps for HTML reference examples</title>
   <link rel="stylesheet" href="examples.css">
   <script src="api-keys.js"></script>
 </head>
 <body>
 <h1>Examples for
-  <a href="../#use-case-***ID***">Use Case: ***Title***</a>
+  <a href="../#use-case-reset-map-view">Use Case: Reset the map to the initial view</a>
 </h1>
 
 <p>

--- a/examples/set-view-zoom.html
+++ b/examples/set-view-zoom.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>***Description*** — Maps for HTML reference examples</title>
+  <title>Move a map to a new position and/or zoom level — Maps for HTML reference examples</title>
   <link rel="stylesheet" href="examples.css">
   <script src="api-keys.js"></script>
 </head>
 <body>
 <h1>Examples for
-  <a href="../#use-case-***ID***">Use Case: ***Title***</a>
+  <a href="../#use-case-set-view-zoom">Use Case: Move a map to a new position and/or zoom level</a>
 </h1>
 
 <p>

--- a/examples/show-and-hide-features-overlays.html
+++ b/examples/show-and-hide-features-overlays.html
@@ -1,10 +1,147 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="UTF-8">
-<title>Title</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Show/hide map layers or feature sets — Maps for HTML reference examples</title>
+  <link rel="stylesheet" href="examples.css">
+  <script src="api-keys.js"></script>
 </head>
 <body>
+<h1>Examples for
+  <a href="../#use-case-hide-layers">Use Case: Show/hide map layers or feature sets</a>
+</h1>
 
+<p>
+***Introduction***
+</p>
+
+<details>
+  <summary>Jump to section…</summary>
+  <ul class="toc">
+    <li>Iframe embeds: <ul>
+      <li><a href="#google-maps-embed">Google Maps embed</a></li>
+      <li><a href="#openstreetmap">OpenStreetMap embed</a></li>
+      <li><a href="#bing-maps-embed">Bing Maps embed</a></li>
+      <li><a href="#mapbox-embed">Mapbox Studio embed</a></li>
+    </ul></li>
+    <li>Client-side frameworks: <ul>
+      <li><a href="#leaflet-js">Leaflet.js API</a></li>
+      <li><a href="#openlayers">OpenLayers API</a></li>
+      <li><a href="#google-maps-api">Google Maps Platform API</a></li>
+      <li><a href="#bing-maps-api">Bing Maps Control API</a></li>
+      <li><a href="#mapkit-js">MapKit JS (Apple Maps) API</a></li>
+      <li><a href="#mapbox-api">Mapbox GL JS API</a></li>
+      <li><a href="#tomtom">TomTom Maps SDK for Web with vector maps</a></li>
+      <li><a href="#d3-geo">D3 Geographies APIs</a></li>
+    </ul></li>
+  </ul>
+</details>
+
+<section id="google-maps-embed">
+  <h2>Google Maps embed</h2>
+
+***TODO<!--
+Copy & paste embed code or <p>Not applicable</p>
+-->***
+</section>
+
+<section id="openstreetmap">
+  <h2>OpenStreetMap embed</h2>
+
+***TODO<!--
+Copy & paste embed code or <p>Not applicable</p>
+-->***
+</section>
+
+<section id="bing-maps-embed">
+  <h2>Bing Maps embed</h2>
+
+***TODO<!--
+Copy & paste embed code or <p>Not applicable</p>
+-->***
+</section>
+
+<section id="mapbox-embed">
+  <h2>MapBox Studio embed</h2>
+
+***TODO<!--
+Copy & paste embed code or <p>Not applicable</p>
+-->***
+</section>
+
+<section id="leaflet-js">
+  <h2>Leaflet.js (with OpenStreetMap tiles)</h2>
+
+***TODO<!--
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
+or <p>Not applicable</p>
+-->***
+</section>
+
+<section id="openlayers">
+  <h2>OpenLayers with OpenStreetMap tiles</h2>
+
+***TODO<!--
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
+or <p>Not applicable</p>
+-->***
+</section>
+
+<section id="google-maps-api">
+  <h2>Google Maps API</h2>
+
+***TODO<!--
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
+or <p>Not applicable</p>
+-->***
+</section>
+
+<section id="bing-maps-api">
+  <h2>Bing Maps Control API</h2>
+
+***TODO<!--
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
+or <p>Not applicable</p>
+-->***
+</section>
+
+<section id="mapkit-js">
+  <h2>MapKit JS (Apple Maps) API</h2>
+
+***TODO<!--
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
+or <p>Not applicable</p>
+-->***
+</section>
+
+<section id="mapbox-api">
+  <h2>Mapbox GL JS API</h2>
+
+***TODO<!--
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
+or <p>Not applicable</p>
+-->***
+</section>
+
+<section id="tomtom">
+  <h2>TomTom Maps SDK for Web with vector maps</h2>
+
+***TODO<!--
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
+or <p>Not applicable</p>
+-->***
+</section>
+
+<section id="d3-geo">
+  <h2>D3 Geographies APIs</h2>
+
+***TODO<!--
+Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.
+or <p>Not applicable</p>
+-->***
+</section>
 </body>
 </html>

--- a/examples/technical-drawings.html
+++ b/examples/technical-drawings.html
@@ -73,7 +73,7 @@
 </section>
 
 <section id="leaflet-js">
-  <h2>Leaflet.js (with OpenStreetMap tiles)</h2>
+  <h2>Leaflet.js</h2>
   <div id="leaflet-js-map" style="width: 600px; height: 450px;"></div>
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.5.1/dist/leaflet.css"
         integrity="sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ=="
@@ -96,7 +96,7 @@
 </section>
 
 <section id="openlayers">
-  <h2>OpenLayers with OpenStreetMap tiles</h2>
+  <h2>OpenLayers</h2>
   <div id="openlayers-map" style="width: 600px; height: 450px;"></div>
   <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css" type="text/css">
   <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
@@ -202,7 +202,7 @@
 </section>
 
 <section id="tomtom">
-  <h2>TomTom Maps SDK for Web with vector maps</h2>
+  <h2>TomTom Maps SDK for Web</h2>
 
   ***TODO<!--
   Replace with code including link/external scripts. Custom script has <code class="script-example"> parent element.

--- a/examples/view-change-events.html
+++ b/examples/view-change-events.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>***Description*** — Maps for HTML reference examples</title>
+  <title>Provide feedback to a user as they manipulate the map — Maps for HTML reference examples</title>
   <link rel="stylesheet" href="examples.css">
   <script src="api-keys.js"></script>
 </head>
 <body>
 <h1>Examples for
-  <a href="../#use-case-***ID***">Use Case: ***Title***</a>
+  <a href="../#use-case-view-change-events">Use Case: Provide feedback to a user as they manipulate the map</a>
 </h1>
 
 <p>


### PR DESCRIPTION
https://github.com/Maps4HTML/HTML-Map-Element-UseCases-Requirements/pull/231/commits/207f9b2a206fb3cd702eb4ee5c7370b3b7e4a9bb: Add missing page titles/headings/links to the corresponding use case in the report.

https://github.com/Maps4HTML/HTML-Map-Element-UseCases-Requirements/pull/231/commits/8cabc7115a668986b3d9f0a9ec26ae78186742de: As @AmeliaBR said in her presentation today: "This is Leaflet JS... *NOT* with OpenStreetMap tiles".