### PR TITLE
fix incorrect `data-ucr-role` for "Display map content in a users preferred language"

### DIFF
--- a/index.html
+++ b/index.html
@@ -2895,7 +2895,7 @@ This capability is fundamental to building progressively enhanced maps.
 </ul>
 </section>
 
-<section id="use-case-preferred-language" data-ucr-role="capability">
+<section id="capability-preferred-language" data-ucr-role="capability">
 <h4>Display map content in a users preferred language</h4>
 <p>
 

--- a/index.html
+++ b/index.html
@@ -2895,7 +2895,7 @@ This capability is fundamental to building progressively enhanced maps.
 </ul>
 </section>
 
-<section id="use-case-preferred-language" data-ucr-role="use-case">
+<section id="use-case-preferred-language" data-ucr-role="capability">
 <h4>Display map content in a users preferred language</h4>
 <p>
 


### PR DESCRIPTION
"[Display map content in a users preferred language](https://maps4html.org/HTML-Map-Element-UseCases-Requirements/#use-case-preferred-language)" is a Capability, thus changed `data-ucr-role` to `capability`. Also changed the `id`.

FYI I've checked the entire list of Capabilities and Use Cases, this was the only one specified incorrectly.