### PR TITLE
Implementation notes for #capability-declarative-map

### DIFF
--- a/index.html
+++ b/index.html
@@ -2524,17 +2524,20 @@ The limitation of custom elements, currently, is that they require extra polyfil
 in addition to the mapping library JavaScript.
 </p>
 <dl data-ucr-role="implementation-notes">
-<!-- Use dt elements to name the implementation, using the id string to create an auto-link.
-     Give details about what is/isn't supported in the dd element,
-     starting with a link to one of the implementation levels.
-     List full implementations first.
-     Group implementations (multiple dt for the same dd) when they have the same support.
-  -->
-<dt>short-name-embed</dt>
-<dt>short-name-api</dt>
-<dd><a>full support|supported, with limitations|partial support|no support|not applicable</a>:
-TO DO<!-- details about what is/isn't supported -->
-</dd>
+<dt>openstreetmap-embed</dt>
+<dt>bing-maps-embed</dt>
+<dt>google-maps-embed</dt>
+<dt>mapbox-embed</dt>
+<dd><a>supported, with limitations</a>: (as described above)</dd>
+<dt>leaflet-api</dt>
+<dt>open-layers-api</dt>
+<dt>tomtom-sdk</dt>
+<dt>google-maps-api</dt>
+<dt>bing-maps-api</dt>
+<dt>apple-mapkit-js-api</dt>
+<dt>mapbox-gl-api</dt>
+<dt>d3-geographies-api</dt>
+<dd><a>not applicable</a>: JavaScript libraries require scripting and cannot be utilized with HTML code alone.</dd>
 </dl>
 
 <h5>Supported use cases</h5>

--- a/index.html
+++ b/index.html
@@ -2537,7 +2537,7 @@ in addition to the mapping library JavaScript.
 <dt>apple-mapkit-js-api</dt>
 <dt>mapbox-gl-api</dt>
 <dt>d3-geographies-api</dt>
-<dd><a>not applicable</a>: JavaScript libraries require scripting and cannot be utilized with HTML code alone.</dd>
+<dd><a>not applicable</a>: JavaScript libraries require additional scripting from the content author and cannot be utilized with HTML code alone.</dd>
 </dl>
 
 <h5>Supported use cases</h5>


### PR DESCRIPTION
Adds implementation notes for https://maps4html.org/HTML-Map-Element-UseCases-Requirements/#capability-declarative-map.

Let me know if you think I should change something.