### PR TITLE
fix inconsistent naming of tomtom labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -4312,7 +4312,7 @@ Group implementations (multiple dt for the same dd) when they have the same supp
 <dt>mapbox-gl-api</dt>
 <dt>leaflet-api</dt>
 <dt>open-layers-api</dt>
-<dt>tomtom</dt>
+<dt>tomtom-sdk</dt>
 <dd>
 <p><a>full support</a>:
 Google, Bing, MapKit and TomTom  allow straightforward creation of a map with configuration options.
@@ -4590,7 +4590,7 @@ Group implementations (multiple dt for the same dd) when they have the same supp
 <dt>mapbox-gl-api</dt>
 <dt>leaflet-api</dt>
 <dt>open-layers-api</dt>
-<dt>tomtom</dt>
+<dt>tomtom-sdk</dt>
 <dd><a>full support</a>:
 <p>
 All of these implementations fully support the concept of controls,
@@ -4731,7 +4731,7 @@ Group implementations (multiple dt for the same dd) when they have the same supp
 <dt>bing-maps-api</dt>
 <dt>apple-mapkit-js-api</dt>
 <dt>mapbox-gl-api</dt>
-<dt>tomtom</dt>
+<dt>tomtom-sdk</dt>
 <dt>d3-geographies-api</dt>
 <dd><a>full support</a>:
 <!-- details about what is/isn't supported -->
@@ -4813,7 +4813,7 @@ Group implementations (multiple dt for the same dd) when they have the same supp
 <dt>mapbox-gl-api</dt>
 <dt>leaflet-api</dt>
 <dt>open-layers-api</dt>
-<dt>tomtom</dt>
+<dt>tomtom-sdk</dt>
 <dt>d3-geographies-api</dt>
 <dd><a>full support</a>:
 <p>
@@ -5013,7 +5013,7 @@ or by specifying the data directly in code.
 </dd>
 <dt>bing-maps-api</dt>
 <dt>leaflet-api</dt>
-<dt>tomtom</dt>
+<dt>tomtom-sdk</dt>
 <dt>d3-geographies-api</dt>
 <dd><a>partial support</a>:
 <p>
@@ -5099,7 +5099,7 @@ Group implementations (multiple dt for the same dd) when they have the same supp
 <dt>bing-maps-api</dt>
 <dt>apple-mapkit-js-api</dt>
 <dt>mapbox-gl-api</dt>
-<dt>tomtom</dt>
+<dt>tomtom-sdk</dt>
 <dt>d3-geographies-api</dt>
 <dd><a>full support</a>:
 All of these implementations allow hiding and showing a layer on a map.
@@ -5489,7 +5489,7 @@ Group implementations (multiple dt for the same dd) when they have the same supp
 <dt>mapbox-gl-api</dt>
 <dt>leaflet-api</dt>
 <dt>open-layers-api</dt>
-<dt>tomtom</dt>
+<dt>tomtom-sdk</dt>
 <dt>d3-geographies-api</dt>
 <dd><a>supported, with limitations</a>:
 <!-- details about what is/isn't supported -->


### PR DESCRIPTION
There are 7 instances of `<dt>tomtom</dt>` and 23 instances of `<dt>tomtom-sdk</dt>`, changing all to `tomtom-sdk`.