### PR TITLE
Add non-map uses and related web specs

### DIFF
--- a/index.html
+++ b/index.html
@@ -4016,7 +4016,7 @@ and may not reflect the users text size preference.
 
 <h5>Related web specifications</h5>
 <p>
-The SVG <a href="https://dev.w3.org/SVG/modules/vectoreffects/master/SVGVectorEffects.html">Vector Effects specification</a>
+The SVG2 <a href="https://svgwg.org/svg2-draft/coords.html#VectorEffects"><code>vector-effects</code> property</a>
 contains a <code>non-scaling-stroke</code> property
 that allows for an object's stroke to be unaffected by transforms and zoom.
 This can be used for data visualization,
@@ -4072,10 +4072,15 @@ where showing different resolutions would be beneficial for performance.
 <h5>Related web specifications</h5>
 <p>
 The <a data-cite="HTML/embedded-content.html#element-attrdef-img-srcset">HTML Picture element</a>
-is an example of a native way for authors to specify different resolutions of the same image.
+is an example of a native way for authors to specify different versions of an image for display at different sizes.
 The author can pass as many <code>source</code> elements as needed as child elements of the <code>picture</code> element,
 and each source has a media attribute that accepts a media query for what environments the referenced file should be used in.
-While this syntax may be too verbose to apply to map tiles due to the need to support multiple zoom levels,
+For simpler cases (the same image rendered at different resolutions),
+the <code>srcset</code> and <code>sizes</code> attributes on an HTML <code>&lt;img&gt;</code> element
+can be used to similar effect.
+While either syntax may be too verbose for use with map tiles
+(they require full URLs for every image, at multiple zoom levels, to be specified in the code,
+and would require the same number of tiles regardless of zoom level)
 it does serve as an example of this functionality being provided in the HTML specification.
 </p>
 </section>
@@ -4117,7 +4122,9 @@ Chart and diagram authors may want to have control over the level of detail disp
 <p>
 In SVG, authors most frequently accomplish this by using <a data-cite="mediaqueries-4">Media Queries</a>
 to hide and show elements based on the window size,
-but <a data-cite="css-contain-1">CSS Containment</a> may potentially provide a more elegant solution
+but this approach is limited to cases where the graphic fills the full document window
+(or <code>&lt;iframe&gt;</code>).
+<a data-cite="css-contain-1">CSS Containment</a> may potentially provide a more elegant solution
 for allowing authors to manipulate features based on the size of the container
 rather than the size of the window.
 </p>
@@ -4187,14 +4194,15 @@ such as 'stroke width', 'fill', 'opacity'.
 <h5>Related web specifications</h5>
 <p>
 <a data-cite="SVG2">SVG elements</a> have many styling properties,
-some of which are element specific.
-These properties may fall under geometry properties,
-which may or may not be only defined within the markup,
-or CSS properties, which may be shared with CSS in general.
+describing the fill color or patterns as well as stroke (outline) color, size, and dashing patterns.
+These are specified using CSS methods (e.g., classes and other selectors)
+or directly as element attributes.
+In addition, SVG 2 allows some aspects of the vector shape's geometry to be specified in CSS.
 </p>
 <p>
 <a data-cite="HTML#custom-elements">Custom elements</a> are able to isolate styles via the Shadow DOM,
-which prevents styling entering or exiting the component.
+which prevents style selectors defined outside the component to match elements within it,
+or vice versa, while still allowing some style inheritance.
 A similar approach could be useful for scoping map specific styling to its containing element.
 </p>
 
@@ -4273,6 +4281,8 @@ and set the position of the controls.
 <p>
 <a data-cite="HTML#custom-elements">Custom elements</a> are encapsulated pieces of functionality
 that can inherit styling from the context that they are in.
+[[[css-shadow-parts-1]]] allows web component authors to expose named parts
+within their custom element's shadow DOM, for styling by the web page author.
 A custom element based approach would allow for map authors to style the map controls
 without requiring them to implement the logic behind them manually.
 </p>

--- a/index.html
+++ b/index.html
@@ -3967,6 +3967,16 @@ re-fetch the same tiles as the user pans across the map.
 <dd><a>full support</a>: (as describe above)
 </dd>
 </dl>
+
+<h5>Uses beyond mapping</h5>
+<p>
+Some UI patterns commonly found on the web,
+such as carousels and marquees,
+utilize a similar kind of wrapping logic.
+Since the marquee element was declared obsolete,
+there is no way to incorporate wrapping/looping functionality natively,
+so incorporating this feature into web maps may have other potential benefits.
+</p>
 </section>
 
 <section id="capability-scale-adjust" data-ucr-role="capability">
@@ -3975,6 +3985,10 @@ re-fetch the same tiles as the user pans across the map.
 Zooming a map widget is different from
 magnifying a regular image, or adjusting the overall browser zoom level;
 the layout is magnified, but annotations such as text size and stroke width are not.
+</p>
+<p>
+It should be noted that the Web Content Accessibility Guidelines <a href="https://www.w3.org/WAI/WCAG21/Understanding/resize-text.html">Success Criterion 1.4.4</a>
+requires that all text be zoomable indepedent of the content by up to 200%.
 </p>
 <p class="issue discussion" data-number="151">
 Discuss this section on GitHub.
@@ -3999,6 +4013,19 @@ and may not reflect the users text size preference.
 <dd><a>full support</a>: (as described above)
 </dd>
 </dl>
+
+<h5>Related web specifications</h5>
+<p>
+The SVG <a href="https://dev.w3.org/SVG/modules/vectoreffects/master/SVGVectorEffects.html">Vector Effects specification</a>
+contains a <code>non-scaling-stroke</code> property
+that allows for an object's stroke to be unaffected by transforms and zoom.
+This can be used for data visualization,
+such as graphs or diagrams
+where an author may want to display a line with a consistent width across a responsive SVG
+that still respects the browser zoom level,
+which may otherwise appear too small on mobile screens
+and too big on larger screens.
+</p>
 </section>
 
 <section id="capability-zoom-swap" data-ucr-role="capability">
@@ -4035,6 +4062,22 @@ in order to provide an indication of the tile type before it has loaded.
 <dd><a>full support</a>: (as described above)
 </dd>
 </dl>
+
+<h5>Uses beyond mapping</h5>
+<p>
+Diagram and chart authors on the web often find themselves in a situation
+where showing different resolutions would be beneficial for performance.
+</p>
+
+<h5>Related web specifications</h5>
+<p>
+The <a data-cite="HTML/embedded-content.html#element-attrdef-img-srcset">HTML Picture element</a>
+is an example of a native way for authors to specify different resolutions of the same image.
+The author can pass as many <code>source</code> elements as needed as child elements of the <code>picture</code> element,
+and each source has a media attribute that accepts a media query for what environments the referenced file should be used in.
+While this syntax may be too verbose to apply to map tiles due to the need to support multiple zoom levels,
+it does serve as an example of this functionality being provided in the HTML specification.
+</p>
 </section>
 
 <section id="capability-zoom-swap-vectors" data-ucr-role="capability">
@@ -4063,6 +4106,21 @@ with their default tilesets.</p>
 <dd><a>full support</a>: (as described above)
 </dd>
 </dl>
+
+<h5>Uses beyond mapping</h5>
+<p>
+This is another capability that could have applications in SVG and other drawing-based web specifications.
+Chart and diagram authors may want to have control over the level of detail displayed at different zoom levels and canvas sizes.
+</p>
+
+<h5>Related web specifications</h5>
+<p>
+In SVG, authors most frequently accomplish this by using <a data-cite="mediaqueries-4">Media Queries</a>
+to hide and show elements based on the window size,
+but <a data-cite="css-contain-1">CSS Containment</a> may potentially provide a more elegant solution
+for allowing authors to manipulate features based on the size of the container
+rather than the size of the window.
+</p>
 </section>
 
 </section>
@@ -4126,15 +4184,18 @@ such as 'stroke width', 'fill', 'opacity'.
 <h5>Supported use cases</h5>
 <ul data-ucr-role="capability-uses"><!-- auto-generated from use case required capabilities --></ul>
 
-<h5>Uses beyond mapping</h5>
-<p>
-<!-- What other web content could use this specific capability? Be brief but specific. -->
-</p>
-
 <h5>Related web specifications</h5>
 <p>
-<!-- Any existing/proposed specs that address similar needs or otherwise interact.
-      Include links with proper ReSpec references. -->
+<a data-cite="SVG2">SVG elements</a> have many styling properties,
+some of which are element specific.
+These properties may fall under geometry properties,
+which may or may not be only defined within the markup,
+or CSS properties, which may be shared with CSS in general.
+</p>
+<p>
+<a data-cite="HTML#custom-elements">Custom elements</a> are able to isolate styles via the Shadow DOM,
+which prevents styling entering or exiting the component.
+A similar approach could be useful for scoping map specific styling to its containing element.
 </p>
 
 <h5>Conclusion</h5>
@@ -4197,7 +4258,7 @@ and set the position of the controls.
 <dt>openstreetmaps-embed</dt>
 <dt>bing-maps-embed</dt>
 <dt>mapbox-embed</dt>
-  <dt>bing-maps-api</dt>
+<dt>bing-maps-api</dt>
 <dt>apple-mapkit-js-api</dt>
 <dd>
   <a>no support</a>:
@@ -4208,15 +4269,17 @@ and set the position of the controls.
 <h5>Supported use cases</h5>
 <ul data-ucr-role="capability-uses"><!-- auto-generated from use case required capabilities --></ul>
 
-<h5>Uses beyond mapping</h5>
-<p>
-<!-- What other web content could use this specific capability? Be brief but specific. -->
-</p>
-
 <h5>Related web specifications</h5>
 <p>
-<!-- Any existing/proposed specs that address similar needs or otherwise interact.
-      Include links with proper ReSpec references. -->
+<a data-cite="HTML#custom-elements">Custom elements</a> are encapsulated pieces of functionality
+that can inherit styling from the context that they are in.
+A custom element based approach would allow for map authors to style the map controls
+without requiring them to implement the logic behind them manually.
+</p>
+<p>
+<a data-cite="HTML#the-input-element">HTML form elements</a> have traditionally lacked ways for web developers to style them,
+which has led to developers implementing their own versions of form elements in order to apply their own styling,
+often to the detriment of semantics and accessibility.
 </p>
 
 <h5>Conclusion</h5>
@@ -4293,8 +4356,8 @@ setting a boolean in a configuration object.
 
 <h5>Related web specifications</h5>
 <p>
-<!-- Any existing/proposed specs that address similar needs or otherwise interact.
-      Include links with proper ReSpec references. -->
+HTML Media Elements (which consists of the <code>&lt;video&gt;</code> and <code>&lt;audio&gt;</code> element)
+include a <a data-cite="HTML#attr-media-controls">controls</a> attribute that indicate whether or not the author would like the user agent to display controls.
 </p>
 
 <h5>Conclusion</h5>


### PR DESCRIPTION
Finish up non map use cases and related specs for widget capabilities. 

One question, is this line too much of a value judgement? I had 'mention the demand for html form elements styling' in my notes.

> HTML form elements have traditionally lacked ways for web developers to style them,
which has led to developers implementing their own versions of form elements in order to apply their own styling,
often to the detriment of semantics and accessibility.
