### PR TITLE
Update link and add reference to the spatial navigation spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -3843,7 +3843,8 @@ Important differences:
 </ul>
 <p>
 Panning interactions also overlap with the proposed
-<a href="https://github.com/WICG/spatial-navigation">CSS spatial navigation</a> spec.
+<a href="https://www.w3.org/TR/css-nav-1/">CSS spatial navigation</a> spec.
+[[css-nav-1]]
 </p>
 <p>
 In web maps and many other applications,


### PR DESCRIPTION
Since CSSWG adopted the specification I believe we should no longer link to the WICG repo but the latest published version of the spec at https://www.w3.org/TR/css-nav-1/.