### PR TITLE
Fixes to 2 examples

### DIFF
--- a/examples/custom-map.html
+++ b/examples/custom-map.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Specify a data source for a map — Maps for HTML reference examples</title>
+  <title>Specify a data source for a map tile layer — Maps for HTML reference examples</title>
   <link rel="stylesheet" href="examples.css">
   <script src="api-keys.js"></script>
 </head>
 <body>
 <h1>Examples for
   <a href="../#use-case-specify-data-source-map">
-    Use Case: Specify a data source for a map
+    Use Case: Display custom imagery as a map layer
   </a>
 </h1>
 

--- a/examples/set-layer-visibility.html
+++ b/examples/set-layer-visibility.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Control which layers are currently visible & which can be hidden by the user</title>
+  <title>Control which layers are currently visible & which can be hidden by the user — Maps for HTML reference examples</title>
   <link rel="stylesheet" href="examples.css">
   <script src="api-keys.js"></script>
   <script src="data/fisk-maps.js"></script>
@@ -13,7 +13,7 @@
 <body>
 <h1>Examples for
   <a href="../#use-case-set-layer-visibility">
-    Control which layers are currently visible & which can be hidden by the user
+    Use Case: Control which layers are currently visible & which can be hidden by the user
   </a>
 </h1>
 


### PR DESCRIPTION
Changes in https://github.com/Maps4HTML/HTML-Map-Element-UseCases-Requirements/commit/b4361856236aacf4e5e2e29bd6827ccee3fbee1e are motivated by:

The use case: <q>[Display custom imagery as a map layer](https://maps4html.org/HTML-Map-Element-UseCases-Requirements/#use-case-custom-map)</q> (note this URL fragment's id includes "custom-map") says:

> See [examples of specifying a data source for a map tile layer](https://maps4html.org/HTML-Map-Element-UseCases-Requirements/examples/custom-map.html)

(link points to custom-map.html)

and the example's `<h1>` says: <q>Examples for Use Case: Specify a data source for a map</q> which seems to be incorrect because it should be (link back to) <q>Display custom imagery as a map layer</q>, so changing to that.

Makes you wonder what [specify-data-source-map.html](https://github.com/Maps4HTML/HTML-Map-Element-UseCases-Requirements/blob/master/examples/specify-data-source-map.html) is for...


