### PR TITLE
Update to references

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,10 @@ a[href]:hover .tag-span, a[href]:focus .tag-span {
 var respecConfig = {
   // specification status (e.g. WD, LCWD, WG-NOTE, etc.). If in doubt use ED.
   specStatus:  "CG-DRAFT",
+  
+  // Temporarily prevent ReSpec from generating a "Latest published version" link
+  // which returns a 404 status code.
+  latestVersion: null,
 
   // if your specification has a subtitle that goes below the main
   // formal title, define it here

--- a/index.html
+++ b/index.html
@@ -129,11 +129,6 @@ var respecConfig = {
 
   xref: false,
   localBiblio: {
-    "MapML" : {
-      title: "Map Markup Language",
-      href: "https://maps4html.org/MapML/spec/",
-      publisher: "Maps for HTML Community Group"
-    },
     "webcomponents-design-guidelines" : {
       title: "Guidelines for creating web platform compatible components",
       href: "https://www.w3.org/2001/tag/doc/webcomponents-design-guidelines/",
@@ -300,7 +295,7 @@ as outlined in <a href="#principles">the guiding principles</a> for this report.
 <p>
 The initial requirements sketched out at LGD2014
 were expanded into <a href="draft-2015.html">an initial use cases and requirements summary</a>.
-That work was the basis of the draft [[[MapML]]] specification.
+That work was the basis of the draft [[[MapML]]].
 Although MapML has had notable support and development efforts
 from within the geospatial community,
 as of early 2019 it has not received significant support

--- a/index.html
+++ b/index.html
@@ -134,11 +134,6 @@ var respecConfig = {
       href: "https://maps4html.org/MapML/spec/",
       publisher: "Maps for HTML Community Group"
     },
-    "HTML-map-element" : {
-      title: "The HTML map Element proposal",
-      href: "https://maps4html.org/HTML-Map-Element/spec/",
-      publisher: "Maps for HTML Community Group"
-    },
     "webcomponents-design-guidelines" : {
       title: "Guidelines for creating web platform compatible components",
       href: "https://www.w3.org/2001/tag/doc/webcomponents-design-guidelines/",
@@ -305,8 +300,7 @@ as outlined in <a href="#principles">the guiding principles</a> for this report.
 <p>
 The initial requirements sketched out at LGD2014
 were expanded into <a href="draft-2015.html">an initial use cases and requirements summary</a>.
-That work was the basis of the draft [[[MapML]]] specification
-and [[[HTML-map-element]]].
+That work was the basis of the draft [[[MapML]]] specification.
 Although MapML has had notable support and development efforts
 from within the geospatial community,
 as of early 2019 it has not received significant support


### PR DESCRIPTION
- [x] https://github.com/Maps4HTML/HTML-Map-Element-UseCases-Requirements/commit/da4801adb23cdd814d8b1ac821c5e69077acdc75 removes the link to the obsolete HTML-Map-Element spec.
- [x] https://github.com/Maps4HTML/HTML-Map-Element-UseCases-Requirements/commit/cd755bccb0ca0a2d811be75954cb2be869ba83e6 removes the MapML entry in `localBiblio`, as MapML is now available through SpecRef:
  https://github.com/tobie/specref/pull/674 👌
- [x] https://github.com/Maps4HTML/HTML-Map-Element-UseCases-Requirements/commit/5ae767ffb4df917b9fab8f108b11c62cbc43e7e6 temporarily prevent ReSpec from generating a link to the "Latest published version" which returns a 404 status code.