### PR TITLE
Fix link destination to Use Case: Display custom imagery as a map layer

### DIFF
--- a/examples/custom-map.html
+++ b/examples/custom-map.html
@@ -11,7 +11,7 @@
 </head>
 <body>
 <h1>Examples for
-  <a href="../#use-case-specify-data-source-map">
+  <a href="../#use-case-custom-map">
     Use Case: Display custom imagery as a map layer
   </a>
 </h1>


### PR DESCRIPTION
This change should have been part of https://github.com/Maps4HTML/HTML-Map-Element-UseCases-Requirements/pull/249.