### PR TITLE
Remove WGS84 from `localBiblio` ReSpec config

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,11 +138,6 @@ var respecConfig = {
       href: "https://www.w3.org/2001/tag/doc/webcomponents-design-guidelines/",
       publisher: "W3C TAG"
     },
-    "WGS84" : {
-      title: "World Geodetic System 1984",
-      href: "http://earth-info.nga.mil/GandG/publications/tr8350.2/wgs84fin.pdf",
-      publisher: "US National Imagery and Mapping Agency"
-    },
     "FAST" : {
       title: "Framework for Accessible Specification of Technologies",
       href: "https://w3c.github.io/apa/fast/",


### PR DESCRIPTION
[Now available in Specref](https://www.specref.org/?q=wgs84) (per https://github.com/tobie/specref/pull/671), also the link (http://earth-info.nga.mil/GandG/publications/tr8350.2/wgs84fin.pdf) is broken anyway.